### PR TITLE
BUG: Modified metadatastore log creation

### DIFF
--- a/metadataStore/sessionManager/databaseLogger.py
+++ b/metadataStore/sessionManager/databaseLogger.py
@@ -2,7 +2,13 @@ __author__ = 'arkilic'
 __version__ = '0.0.2'
 
 import logging
+import os
 
+
+def create_file_logger(filename):
+    if not filename.endswith('.log'):
+        filename += '.log'
+    return logging.FileHandler(filename)
 
 class DbLogger(object):
     def __init__(self, db_name, host, port):
@@ -10,7 +16,13 @@ class DbLogger(object):
         Constructor: MongoClient, Database, and native python loggers are created
         """
         self.logger = logging.getLogger('MetadataStore')
-        log_handler = logging.FileHandler('/tmp/MetaDataStore.log')
+        log_root = '/tmp/MetaDataStore'
+        try:
+            log_handler = create_file_logger(log_root)
+        except IOError:
+            # probably permission denied because of user permissions
+            log_root += '_{}'.format(os.getlogin())
+            log_handler = create_file_logger(log_root)
         formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
         log_handler.setFormatter(formatter)
         self.logger.addHandler(log_handler)


### PR DESCRIPTION
- Metadatastore will now first attempt to create a log titled:
  '/tmp/MetaDataStore.log'
- If that fails, it will append _username and create it again.
