### PR TITLE
API: Remove nested api

### DIFF
--- a/example/synthetic_cosine.py
+++ b/example/synthetic_cosine.py
@@ -16,7 +16,8 @@ data_keys = {'linear_motor': {'source': 'PV:pv1',
                                  'shape': None,
                                  'dtype': 'number'},
              'Tsam': {'source': 'PV:pv3',
-                      'dtype': 'number'}
+                      'dtype': 'number',
+                      'shape': None}
              }
 
 try:
@@ -49,11 +50,11 @@ sleep_time = .1
 for idx, i in enumerate(np.linspace(start, stop, num)):
     data = {'linear_motor': [i, time.time()],
             'Tsam': [i + 5, time.time()],
-            'scalar_detector': [func(i), time.time()]}
+            'scalar_detector': [func(i) + np.random.randn() / 100, time.time()]}
     e = insert_event(event_descriptor=e_desc, seq_num=idx,
                      time=time.time(),
                      data=data)
-    time.sleep(sleep_time)
+    # time.sleep(sleep_time)
 last_run = find_last()[0]
 
 try:

--- a/metadataStore/api.py
+++ b/metadataStore/api.py
@@ -1,0 +1,11 @@
+# Data retrieval
+from .commands import (find, find_event, find_event_descriptor,
+                       find_beamline_config, find_begin_run, find_last,
+                       find_event_given_descriptor, fetch_events)
+# Data insertion
+from .commands import (insert_event, insert_event_descriptor, insert_begin_run,
+                       insert_beamline_config, insert_end_run,
+                       EventDescriptorIsNoneError, format_events,
+                       format_data_keys)
+
+from .document import Document

--- a/metadataStore/api/__init__.py
+++ b/metadataStore/api/__init__.py
@@ -1,2 +1,0 @@
-__author__ = 'arkilic'
-

--- a/metadataStore/api/analysis.py
+++ b/metadataStore/api/analysis.py
@@ -1,7 +1,0 @@
-__author__ = 'arkilic'
-
-
-from ..commands import (find, find_event, find_event_descriptor,
-                        find_beamline_config, find_begin_run, find_last,
-                        find_event_given_descriptor, fetch_events)
-

--- a/metadataStore/api/collection.py
+++ b/metadataStore/api/collection.py
@@ -1,8 +1,0 @@
-__author__ = 'arkilic'
-
-
-from ..commands import (
-    insert_event, insert_event_descriptor, insert_begin_run,
-    insert_beamline_config, insert_end_run, EventDescriptorIsNoneError,
-    format_events, format_data_keys
-)

--- a/metadataStore/commands.py
+++ b/metadataStore/commands.py
@@ -264,8 +264,7 @@ def insert_event(event_descriptor, time, data, seq_num, uid=None):
     # TODO: seq_no is not optional according to opyhd folks. To be discussed!!
     # talk to @dchabot & @swilkins
     event = Event(descriptor_id=event_descriptor, uid=uid,
-                  data=m_data, time=time, seq_num=seq_num,
-                  time_as_datetime=__todatetime(time))
+                  data=m_data, time=time, seq_num=seq_num)
 
     event = __replace_event_data_key_dots(event, direction='in')
     event.save(validate=True, write_concern={"w": 1})
@@ -329,8 +328,9 @@ def find_begin_run(limit=50, **kwargs):
 
     Returns
     -------
-    br_objects : mongoengine.QuerySet
-        Corresponding BeginRunObjects given search criteria
+    br_objects : metadataStore.document.Document
+        Combined documents: BeginRunEvent, BeamlineConfig, Sample and
+        EventDescriptors
 
     Usage
     ------
@@ -400,9 +400,13 @@ def find_beamline_config(_id):
     ----------
     _id: bson.ObjectId
 
+    Returns
+    -------
+    beamline_config : metadataStore.document.Document
+        The beamline config object
     """
-    cfg = BeamlineConfig.objects(id=_id).order_by('-_id')
-    return __as_document(cfg)
+    beamline_config = BeamlineConfig.objects(id=_id).order_by('-_id')
+    return __as_document(beamline_config)
 
 @db_connect
 def find_event_descriptor(begin_run_event):
@@ -412,6 +416,10 @@ def find_event_descriptor(begin_run_event):
     ----------
     begin_run_event : bson.ObjectId
 
+    Returns
+    -------
+    event_descriptor : list
+        List of metadataStore.document.Document.
     """
     event_descriptor_list = list()
     for event_descriptor in EventDescriptor.objects\
@@ -433,6 +441,11 @@ def fetch_events(limit=1000, **kwargs):
         time of the event. dict keys must be start and end
     descriptor : mongoengine.Document, optional
         event descriptor object
+
+    Returns
+    -------
+    events : list
+        List of metadataStore.document.Document
     """
     search_dict = dict()
     try:
@@ -472,13 +485,14 @@ def find_event(begin_run_event):
     Returns
     -------
     events: list
-        Set of events encapsulated within a BeginRunEvent's scope
+        Set of events encapsulated within a BeginRunEvent's scope.
+        metadataStore.document.Document
     """
     descriptors = EventDescriptor.objects(begin_run_event=begin_run_event.id)
     descriptors = descriptors.order_by('-_id')
     events = [find_event_given_descriptor(descriptor)
               for descriptor in descriptors]
-    return [__as_document(ev) for ev in events]
+    return events
 
 @db_connect
 def find_event_given_descriptor(event_descriptor):
@@ -489,6 +503,11 @@ def find_event_given_descriptor(event_descriptor):
     event_descriptor: metadataStore.database.EventDescriptor
         EventDescriptor instance that a set of events point back to
 
+    Returns
+    -------
+    event_list : list
+        Nested list. top level is each event descriptor. next level is events
+        [[ev0, ev1, ...], [ev0, ev1, ...]]
     """
     event_list = list()
     for event in Event.objects(
@@ -522,11 +541,12 @@ def find(data=True, limit=50, **kwargs):
 
     Returns
     -------
-    result: mongoengine.Document
+    result: metadataStore.document.Document
         Returns BeginRunEvent objects
         One can access events for this given BeginRunEvent as:
         begin_run_object.events
     """
+    raise NotImplementedError()
     br_objects = find_begin_run(limit, **kwargs)
 
     if data:
@@ -535,7 +555,7 @@ def find(data=True, limit=50, **kwargs):
             for br in br_objects:
                 br.events = find_event(br)
                 result.append(br)
-    return br
+    return br_objects
 
 @db_connect
 def find_last(num=1):
@@ -547,6 +567,7 @@ def find_last(num=1):
     -------
     begin_run_event: list
         Returns a list of the last ``num`` headers created.
+        List of metadataStore.document.Document objects
         **NOTE**: DOES NOT RETURN THE EVENTS.
     """
     br_objects = [br_obj for br_obj in BeginRunEvent.objects.order_by('-_id')[0:num]]

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     author_email=None,
     license="BSD (3-clause)",
     url = "https://github.com/NSLS-II/metadataStore",
-    packages=['metadataStore', 'metadataStore.test','metadataStore.api'],
+    packages=['metadataStore', 'metadataStore.test'],
     long_description=read('README.md'),
     classifiers=[
         "License :: OSI Approved :: EPICS License",


### PR DESCRIPTION
IMO, having `api` as the only sub-package does not pass the sniff test. Also, only return sanitized mongo objects from all find functions.

This will break ophyd and ~~metadatastore~~ dataportal, but those are very easy to fix. I will deal with the changes to both projects if everyone agrees that this PR is a good move.

thoughts @danielballan @tacaswell @arkilic 
