### PR TITLE
FIX: Keep db_connect wrapper from blowing away docstrings.

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
+from functools import wraps
 from .odm_templates import (RunStart, BeamlineConfig, RunStop,
                             EventDescriptor, Event, DataKey)
 from .document import Document
@@ -80,6 +81,7 @@ def format_events(event_dict):
 
 
 def db_connect(func):
+    @wraps(func)
     def inner(*args, **kwargs):
         db = metadatastore.conf.mds_config['database']
         host = metadatastore.conf.mds_config['host']


### PR DESCRIPTION
Before:

```
In [2]: insert_run_start?
Type:        function
String form: <function inner at 0x1041bb8c0>
File:        /Users/dallan/Documents/Repos/metadatastore/metadatastore/commands.py
Definition:  insert_run_start(*args, **kwargs)
Docstring:   <no docstring>
```

After:

```
In [2]: insert_run_start?

Type:        function
String form: <function insert_run_start at 0x1041bb8c0>
File:        /Users/dallan/Documents/Repos/metadatastore/metadatastore/commands.py
Definition:  insert_run_start(*args, **kwargs)
Docstring:
Provide a head for a sequence of events. Entry point for an
experiment's run.

Parameters
----------
time : float
    The date/time as found at the client side when an event is
    created.
beamline_id: str
    Beamline String identifier. Not unique, just an indicator of
    beamline code for multiple beamline systems
beamline_config: metadatastore.odm_temples.BeamlineConfig, optional
    Foreign key to beamline config corresponding to a given run
owner: str, optional
    Specifies the unix user credentials of the user creating the entry
scan_id : int, optional
    Unique scan identifier visible to the user and data analysis
custom: dict, optional
    Additional parameters that data acquisition code/user wants to
    append to a given header. Name/value pairs

Returns
-------
run_start: mongoengine.Document
    Inserted mongoengine object
(END) 
```
