### PR TITLE
CLN: Remove log message that LIES.

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -86,8 +86,6 @@ def db_connect(func):
         db = metadatastore.conf.mds_config['database']
         host = metadatastore.conf.mds_config['host']
         port = metadatastore.conf.mds_config['port']
-        logger.debug('connecting to db: %s, host: %s, port: %s',
-                     db, host, port)
         connect(db=db, host=host, port=port)
         return func(*args, **kwargs)
     return inner


### PR DESCRIPTION
This log message says you are connected to the database specified in the log file, even if you are not. That lost me about 2 hours, so consider this a vengeance PR. Better to report nothing that to report something that might be wrong.
