### PR TITLE
WIP: Allow arbitrary searching with find_run_start

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -310,8 +310,10 @@ def find_run_start(limit=50, **kwargs):
     ----------
     limit : int
         Number of header objects to be returned
-    time : dict, optional
-        Formatted like this: {'start': timestamp, 'stop': timestamp}
+    start_time : float, optional
+        timestamp of the earliest time to return run_start events
+    stop_time : float, optional
+        timestamp of the latest time to return run_start events
     scan_id : int, optional
         Scan identifier. Not unique
     owner : str, optional
@@ -345,23 +347,15 @@ def find_run_start(limit=50, **kwargs):
 
     """
     # format time correctly
-    try:
-        start_time = kwargs['start_time']
-    except KeyError:
-        pass
-    else:
-        kwargs['time'] = {'$gte': start_time}
-
-    try:
-        stop_time = kwargs['stop_time']
-    except KeyError:
-        pass
-    else:
-        tt = {'$lte': stop_time}
-        try:
-            kwargs['time'].update(tt)
-        except KeyError:
-            kwargs['time'] = tt
+    time_dict = {}
+    start_time = kwargs.pop('start_time') # defaults to None
+    stop_time = kwargs.pop('stop_time')
+    if start_time:
+        time_dict['$gte'] = start_time
+    if stop_time:
+        time_dict['$lte'] = stop_time
+    if time_dict:
+        kwargs['time'] = time_dict
 
     # do the search
     br_objects = RunStart.objects(__raw__=kwargs).order_by('-_id')[:limit]

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -356,13 +356,10 @@ def find_run_start(limit=50, **kwargs):
         time_dict['$lte'] = stop_time
     if time_dict:
         kwargs['time'] = time_dict
-
     # do the search
     br_objects = RunStart.objects(__raw__=kwargs).order_by('-_id')[:limit]
-
     # add the event descriptors
     __add_event_descriptors(br_objects)
-
     # transform the mongo objects into safe, whitebread python objects
     return [__as_document(bre) for bre in br_objects]
 


### PR DESCRIPTION
Executes a two stage search. Stage 1 uses the keys mongo knows and Stage 2 uses list comprehension to remove results with keys that mongo doesn't know it has.

See example notebook here: http://nbviewer.ipython.org/gist/anonymous/fa3bdd2c284893e0fa48

If everyone likes this functionality, I will expand it to the remaining `find_*` functions in metadatastore and work on integrating it into the databroker api
