### PR TITLE
API: Add mds_setup, mds_teardown testing utils.

### DIFF
--- a/metadatastore/api.py
+++ b/metadatastore/api.py
@@ -6,6 +6,6 @@ from .commands import (find, find_event, find_event_descriptor,
 from .commands import (insert_event, insert_event_descriptor, insert_run_start,
                        insert_beamline_config, insert_run_stop,
                        EventDescriptorIsNoneError, format_events,
-                       format_data_keys)
+                       format_data_keys, db_connect, db_disconnect)
 
 from .document import Document

--- a/metadatastore/conf.py
+++ b/metadatastore/conf.py
@@ -7,14 +7,14 @@ filename = os.path.join(os.path.expanduser('~'), '.config', 'metadatastore',
                         'connection.yml')
 if os.path.isfile(filename):
     with open(filename) as f:
-        mds_config = yaml.load(f)
+        connection_config = yaml.load(f)
     logger.debug("Using db connection specified in config file. \n%r",
-                 mds_config)
+                 connection_config)
 else:
-    mds_config = {
+    connection_config = {
         'database': 'test',
         'host': "localhost",
         'port': 27017,
         }
     logger.debug("Using default db connection. \n%r",
-                 mds_config)
+                 connection_config)

--- a/metadatastore/test/test_commands.py
+++ b/metadatastore/test/test_commands.py
@@ -4,9 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 import uuid
 import time as ttime
-import mongoengine
-import mongoengine.connection
-from mongoengine.context_managers import switch_db
 from ..api import Document as Document
 
 from nose.tools import make_decorator
@@ -16,41 +13,21 @@ from nose.tools import assert_equal, assert_raises
 from metadatastore.odm_templates import (BeamlineConfig, EventDescriptor,
                                          Event, RunStart, RunStop)
 import metadatastore.commands as mdsc
+from metadatastore.utils.testing import mds_setup, mds_teardown
 
-db_name = str(uuid.uuid4())
-dummy_db_name = str(uuid.uuid4())
 blc = None
 
 
 def setup():
+    mds_setup()
     global blc
-
-    # need to make 'default' connection to point to no-where, just to be safe
-    mongoengine.connect(dummy_db_name)
-    # connect to the db we are actually going to use
-    mongoengine.connect(db_name, alias='test_db')
     blc = mdsc.insert_beamline_config({}, ttime.time())
 
 
 def teardown():
-    conn = mongoengine.connection.get_connection('test_db')
-    conn.drop_database(db_name)
-    conn.drop_database(dummy_db_name)
+    mds_teardown()
 
 
-def context_decorator(func):
-    def inner(*args, **kwargs):
-        with switch_db(BeamlineConfig, 'test_db'), \
-          switch_db(EventDescriptor, 'test_db'), \
-          switch_db(Event, 'test_db'), \
-          switch_db(RunStop, 'test_db'), \
-          switch_db(RunStart, 'test_db'):
-            func(*args, **kwargs)
-
-    return make_decorator(func)(inner)
-
-
-@context_decorator
 def _blc_tester(config_dict):
     """Test BeamlineConfig Insert
     """
@@ -69,19 +46,14 @@ def test_blc_insert():
         yield _blc_tester, cfd
 
 
-@context_decorator
 def _ev_desc_tester(run_start, data_keys, time):
     ev_desc = mdsc.insert_event_descriptor(run_start,
                                            data_keys, time)
     Document(ev_desc) # test document creation
     ret = EventDescriptor.objects.get(id=ev_desc.id)
 
-    for k, v in zip(['run_start',
-                     'time'],
-                    [run_start.to_dbref(),
-                     time, ]):
-
-        assert_equal(getattr(ret, k), v)
+    for name, val in zip(['run_start', 'time'], [run_start, time]):
+        assert_equal(getattr(ret, name), val)
 
     for k in data_keys:
         for ik in data_keys[k]:
@@ -124,7 +96,6 @@ def test_src_dst_fail():
     assert_raises(ValueError, mdsc.__src_dst, 'aardvark')
 
 
-@context_decorator
 def _run_start_tester(time, beamline_id, scan_id):
 
     run_start = mdsc.insert_run_start(time, beamline_id, scan_id=scan_id,
@@ -132,9 +103,9 @@ def _run_start_tester(time, beamline_id, scan_id):
     Document(run_start) # test document creation
     ret = RunStart.objects.get(id=run_start.id)
 
-    for k, v in zip(['time', 'beamline_id', 'scan_id'],
-                    [time, beamline_id, scan_id]):
-        assert_equal(getattr(ret, k), v)
+    for name, val in zip(['time', 'beamline_id', 'scan_id'],
+                         [time, beamline_id, scan_id]):
+        assert_equal(getattr(ret, name), val)
 
 
 def test_run_start():
@@ -143,7 +114,6 @@ def test_run_start():
     yield _run_start_tester, time, beamline_id, 42
 
 
-@context_decorator
 def _run_start_with_cfg_tester(beamline_cfg, time, beamline_id, scan_id):
     run_start = mdsc.insert_run_start(time, beamline_id,
                                       beamline_config=beamline_cfg,
@@ -151,9 +121,9 @@ def _run_start_with_cfg_tester(beamline_cfg, time, beamline_id, scan_id):
     Document(run_start) # test document creation
     ret = RunStart.objects.get(id=run_start.id)
 
-    for k, v in zip(['time', 'beamline_id', 'scan_id', 'beamline_config'],
-                    [time, beamline_id, scan_id, beamline_cfg.to_dbref()]):
-        assert_equal(getattr(ret, k), v)
+    for name, val in zip(['time', 'beamline_id', 'scan_id', 'beamline_config'],
+                         [time, beamline_id, scan_id, beamline_cfg]):
+        assert_equal(getattr(ret, name), val)
 
 
 def test_run_start2():
@@ -164,20 +134,18 @@ def test_run_start2():
     yield _run_start_with_cfg_tester, bcfg, time, beamline_id, scan_id
 
 
-@context_decorator
 def _event_tester(descriptor, seq_num, data, time):
     pass
 
 
-@context_decorator
 def _end_run_tester(run_start, time):
     print('br:', run_start)
     end_run = mdsc.insert_run_stop(run_start, time)
     Document(end_run) # test document creation
     ret = RunStop.objects.get(id=end_run.id)
-    for k, v in zip(['id', 'time', 'run_start'],
-                    [end_run.id, time, run_start.to_dbref()]):
-        assert_equal(getattr(ret, k), v)
+    for name, val in zip(['id', 'time', 'run_start'],
+                    [end_run.id, time, run_start]):
+        assert_equal(getattr(ret, name), val)
 
 
 def test_end_run():
@@ -190,7 +158,6 @@ def test_end_run():
     yield _end_run_tester, bre, time
 
 
-@context_decorator
 def test_bre_custom():
     cust = {'foo': 'bar', 'baz': 42,
             'aardvark': ['ants', 3.14]}

--- a/metadatastore/utils/testing.py
+++ b/metadatastore/utils/testing.py
@@ -1,0 +1,18 @@
+import uuid
+from metadatastore.api import db_connect, db_disconnect
+
+
+conn = None
+db_name = str(uuid.uuid4())
+
+
+def mds_setup():
+    "Create a fresh database with unique (random) name."
+    global conn
+    db_disconnect()
+    conn = db_connect(db_name, 'localhost', 27017)
+
+def mds_teardown():
+    "Drop the fresh database and disconnect."
+    conn.drop_database(db_name)
+    db_disconnect()

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     author_email=None,
     license="BSD (3-clause)",
     url = "https://github.com/NSLS-II/metadatastore",
-    packages=['metadatastore', 'metadatastore.test'],
+    packages=['metadatastore', 'metadatastore.test', 'metadatastore.utils'],
     long_description=read('README.md'),
     classifiers=[
         "License :: OSI Approved :: EPICS License",


### PR DESCRIPTION
Just like NSLS-II/filestore#32 but for metadatastore.

Also, this copies the `db_connect`, `db_disconnect`, `_ensure_connection` machinery from FS and standardizes the names.

And finally, it looks like some tests were broken but not being correctly run. This fixes that.
