### PR TITLE
FIX: insert_* commands should accept custom fields

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -203,7 +203,7 @@ def insert_beamline_config(config_params, time, uid=None):
 
     Parameters
     ----------
-    config_params : dict, optional
+    config_params : dict
         Name/value pairs that indicate beamline configuration
         parameters during capturing of data
     time : timestamp

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -166,7 +166,7 @@ def insert_run_stop(run_start, time, uid=None, exit_status='success',
     ----------
     run_start : metadatastore.odm_temples.RunStart
         Foreign key to corresponding RunStart
-    time : timestamp
+    time : float
         The date/time as found at the client side when an event is
         created.
     uid : str, optional
@@ -208,7 +208,7 @@ def insert_beamline_config(config_params, time, uid=None):
     config_params : dict
         Name/value pairs that indicate beamline configuration
         parameters during capturing of data
-    time : timestamp
+    time : float
         The date/time as found at the client side when the
         beamline configuration is created.
     uid : str, optional
@@ -243,7 +243,7 @@ def insert_event_descriptor(run_start, data_keys, time, uid=None,
     data_keys : dict
         Provides information about keys of the data dictionary in
         an event will contain
-    time : timestamp
+    time : float
         The date/time as found at the client side when an event
         descriptor is created.
     uid : str, optional
@@ -288,7 +288,7 @@ def insert_event(event_descriptor, time, data, seq_num, uid=None):
     event_descriptor : metadatastore.odm_templates.EventDescriptor
         EventDescriptor object that specific event entry is going
         to point(foreign key)
-    time : timestamp
+    time : float
         The date/time as found at the client side when an event is
         created.
     data : dict

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -108,7 +108,7 @@ def format_events(event_dict):
 
 @_ensure_connection
 def insert_run_start(time, beamline_id, beamline_config=None, owner=None,
-                     scan_id=None, custom=None, uid=None):
+                     scan_id=None, uid=None, custom=None):
     """ Provide a head for a sequence of events. Entry point for an
     experiment's run.
 

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -126,6 +126,8 @@ def insert_run_start(time, beamline_id, beamline_config=None, owner=None,
         Specifies the unix user credentials of the user creating the entry
     scan_id : int, optional
         Unique scan identifier visible to the user and data analysis
+    uid : str, optional
+        Globally unique id string provided to metadatastore
     custom: dict, optional
         Any additional information that data acquisition code/user wants
         to append to the Header at the start of the run.
@@ -169,6 +171,8 @@ def insert_run_stop(run_start, time, exit_status='success',
         created.
     reason : str, optional
         provides information regarding the run success. 20 characters max
+    uid : str, optional
+        Globally unique id string provided to metadatastore
     custom : dict, optional
         Any additional information that data acquisition code/user wants
         to append to the Header at the end of the run.
@@ -202,6 +206,11 @@ def insert_beamline_config(config_params, time, uid=None):
     config_params : dict, optional
         Name/value pairs that indicate beamline configuration
         parameters during capturing of data
+    time : timestamp
+        The date/time as found at the client side when the
+        beamline configuration is created.
+    uid : str, optional
+        Globally unique id string provided to metadatastore
 
     Returns
     -------
@@ -235,6 +244,8 @@ def insert_event_descriptor(run_start, data_keys, time, uid=None,
     time : timestamp
         The date/time as found at the client side when an event
         descriptor is created.
+    uid : str, optional
+        Globally unique id string provided to metadatastore
     custom : dict, optional
         Any additional information that data acquisition code/user wants
         to append to the EventDescriptor.
@@ -284,6 +295,8 @@ def insert_event(event_descriptor, time, data, seq_num, uid=None):
     seq_num : int
         Unique sequence number for the event. Provides order of an event in
         the group of events
+    uid : str, optional
+        Globally unique id string provided to metadatastore
     """
     m_data = _validate_data(data)
 

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -107,8 +107,8 @@ def format_events(event_dict):
 # database INSERTION ###################################################
 
 @_ensure_connection
-def insert_run_start(time, scan_id, beamline_id, beamline_config, owner=None,
-                     uid=None, custom=None):
+def insert_run_start(time, scan_id, beamline_id, beamline_config, uid=None,
+                     owner=None, custom=None):
     """ Provide a head for a sequence of events. Entry point for an
     experiment's run.
 
@@ -124,10 +124,10 @@ def insert_run_start(time, scan_id, beamline_id, beamline_config, owner=None,
         beamline code for multiple beamline systems
     beamline_config: metadatastore.odm_temples.BeamlineConfig
         Foreign key to beamline config corresponding to a given run
-    owner: str, optional
-        Specifies the unix user credentials of the user creating the entry
     uid : str, optional
         Globally unique id string provided to metadatastore
+    owner: str, optional
+        Specifies the unix user credentials of the user creating the entry
     custom: dict, optional
         Any additional information that data acquisition code/user wants
         to append to the Header at the start of the run.
@@ -157,8 +157,8 @@ def insert_run_start(time, scan_id, beamline_id, beamline_config, owner=None,
 
 
 @_ensure_connection
-def insert_run_stop(run_start, time, exit_status='success',
-                    reason=None, uid=None, custom=None):
+def insert_run_stop(run_start, time, uid=None, exit_status='success',
+                    reason=None, custom=None):
     """ Provide an end to a sequence of events. Exit point for an
     experiment's run.
 
@@ -169,12 +169,12 @@ def insert_run_stop(run_start, time, exit_status='success',
     time : timestamp
         The date/time as found at the client side when an event is
         created.
-    exit_status : {'success', 'abort', 'fail'}
-        indicating reason run stopped
-    reason : str, optional
-        more detailed exit status (stack trace, user remark, etc.)
     uid : str, optional
         Globally unique id string provided to metadatastore
+    exit_status : {'success', 'abort', 'fail'}, optional
+        indicating reason run stopped, 'success' by default
+    reason : str, optional
+        more detailed exit status (stack trace, user remark, etc.)
     custom : dict, optional
         Any additional information that data acquisition code/user wants
         to append to the Header at the end of the run.

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -170,8 +170,9 @@ def insert_run_stop(run_start, time, exit_status='success',
         The date/time as found at the client side when an event is
         created.
     exit_status : {'success', 'abort', 'fail'}
+        indicating reason run stopped
     reason : str, optional
-        provides information regarding the run success. 20 characters max
+        more detailed exit status (stack trace, user remark, etc.)
     uid : str, optional
         Globally unique id string provided to metadatastore
     custom : dict, optional

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -107,8 +107,8 @@ def format_events(event_dict):
 # database INSERTION ###################################################
 
 @_ensure_connection
-def insert_run_start(time, beamline_id, beamline_config=None, owner=None,
-                     scan_id=None, uid=None, custom=None):
+def insert_run_start(time, scan_id, beamline_id, beamline_config, owner=None,
+                     uid=None, custom=None):
     """ Provide a head for a sequence of events. Entry point for an
     experiment's run.
 
@@ -117,15 +117,15 @@ def insert_run_start(time, beamline_id, beamline_config=None, owner=None,
     time : float
         The date/time as found at the client side when an event is
         created.
+    scan_id : int
+        Unique scan identifier visible to the user and data analysis
     beamline_id: str
         Beamline String identifier. Not unique, just an indicator of
         beamline code for multiple beamline systems
-    beamline_config: metadatastore.odm_temples.BeamlineConfig, optional
+    beamline_config: metadatastore.odm_temples.BeamlineConfig
         Foreign key to beamline config corresponding to a given run
     owner: str, optional
         Specifies the unix user credentials of the user creating the entry
-    scan_id : int, optional
-        Unique scan identifier visible to the user and data analysis
     uid : str, optional
         Globally unique id string provided to metadatastore
     custom: dict, optional
@@ -169,6 +169,7 @@ def insert_run_stop(run_start, time, exit_status='success',
     time : timestamp
         The date/time as found at the client side when an event is
         created.
+    exit_status : {'success', 'abort', 'fail'}
     reason : str, optional
         provides information regarding the run success. 20 characters max
     uid : str, optional

--- a/metadatastore/odm_templates.py
+++ b/metadatastore/odm_templates.py
@@ -78,7 +78,9 @@ class RunStop(DynamicDocument):
     run_start : bson.ObjectId
         Foreign key to corresponding RunStart
     exit_status : {'success', 'fail', 'abort'}
-        provides information regarding the run success.
+        indicating reason run stopped
+    reason : str
+        more detailed exit status (stack trace, user remark, etc.)
     time : float
         The date/time as found at the client side when an event is
         created.

--- a/metadatastore/test/test_commands.py
+++ b/metadatastore/test/test_commands.py
@@ -125,7 +125,8 @@ def test_src_dst_fail():
 
 def _run_start_tester(time, beamline_id, scan_id):
 
-    run_start = mdsc.insert_run_start(time, beamline_id, scan_id=scan_id,
+    run_start = mdsc.insert_run_start(time, beamline_id=beamline_id,
+                                      scan_id=scan_id,
                                       beamline_config=blc)
     q_ret, = mdsc.find_run_starts(_id=run_start.id)
     assert_equal(bson.ObjectId(q_ret.id), run_start.id)
@@ -165,7 +166,7 @@ def test_run_start():
 
 
 def _run_start_with_cfg_tester(beamline_cfg, time, beamline_id, scan_id):
-    run_start = mdsc.insert_run_start(time, beamline_id,
+    run_start = mdsc.insert_run_start(time, beamline_id=beamline_id,
                                       beamline_config=beamline_cfg,
                                       scan_id=scan_id)
     Document.from_mongo(run_start)


### PR DESCRIPTION
- `insert_run_start` already implemented `custom`.
- `insert_run_stop` and `insert_event_descriptor` did not, but they should.
- `insert_beamline_config` did not, but it already accepts an arbitrary dictionary, so there is no need for `custom`.

Also, the `uid` and `time` arguments were not documented everywhere. This fixes that.
