### PR TITLE
REF: Load configs from env, /etc, and ~/config in precedence.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p /home/travis/mc
   - export PATH=/home/travis/mc/bin:$PATH
+  - export MDS_HOST=localhost
+  - export MDS_PORT=27017
+  - export MDS_DATABASE=test
 
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`


### PR DESCRIPTION
This PR also refactors the config-loading logic into a function that could be reused by filestore if we can decide on a place to put it. The simple implementation of this function is not compatible with a _nested_ YAML file, but we'll solve that problem when we come to it.
