### PR TITLE
Replace pandas friendly times normalization

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - mongoengine
     - six
     - pyyaml
-    - pandas
 
 test:
   requires:

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -389,14 +389,16 @@ def _normalize_human_friendly_time(val):
 
     tz = conf.connection_config['timezone']  # e.g., 'US/Eastern'
     zone = pytz.timezone(tz)  # tz as datetime.tzinfo object
-    epoch = pytz.UTC.localize(datetime.datetime(1970,1,1))
+    epoch = pytz.UTC.localize(datetime.datetime(1970, 1, 1))
     check = True
 
     if isinstance(val, six.string_types):
-        # unix 'date' cmd format '%a %b %d %H:%M:%S %Z %Y' works but doesn't get TZ?
+        # unix 'date' cmd format '%a %b %d %H:%M:%S %Z %Y' works but
+        # doesn't get TZ?
+
         formats = ['%Y-%m-%d %H:%M:%S',
-                   '%Y-%m-%d %H:%M',  # not as doc'd, but matches previous pandas behavior
-                   '%Y-%m-%d %H',  # not as doc'd, but matches previous pandas behavior
+                   '%Y-%m-%d %H:%M',  # these 2 are not as doc'd, but
+                   '%Y-%m-%d %H',     # match previous pandas behavior
                    '%Y-%m-%d',
                    '%Y-%m',
                    '%Y']
@@ -420,10 +422,10 @@ def _normalize_human_friendly_time(val):
                 val = ts
                 check = False
             else:
-                raise TypeError('expected datetime.datetime, got: '+ repr(ts))
+                raise TypeError('expected datetime.datetime, got: ' + repr(ts))
 
         except NameError:
-            raise ValueError('failed to parse time: '+ repr(val))
+            raise ValueError('failed to parse time: ' + repr(val))
 
     if check and not isinstance(val, datetime.datetime):
         return val

--- a/metadatastore/test/test_commands.py
+++ b/metadatastore/test/test_commands.py
@@ -273,16 +273,17 @@ def _normalize_human_friendly_time_tester(val, should_succeed, etype):
     else:
         assert_raises(etype, mdsc._normalize_human_friendly_time, val)
 
+
 def test_normalize_human_friendly_time():
     # should get tz from conf?  but no other tests get conf stuff...
     zone = pytz.timezone('US/Eastern')
 
     good_test_values = [('2014', 1388552400.0),
-                        ('2014 ', 1388552400.0),  # pandas assumes current month+day
+                        ('2014 ', 1388552400.0),
                         ('2014-02', 1391230800.0),
                         ('2014-02 ', 1391230800.0),
-                        ('2014-2', 1391230800.0),  # pandas assumes current day
-                        ('2014-2 ', 1391230800.0),  # pandas assumes current day
+                        ('2014-2', 1391230800.0),
+                        ('2014-2 ', 1391230800.0),
                         ('2014-2-10', 1392008400.0),
                         ('2014-2-10 ', 1392008400.0),
                         ('2014-02-10', 1392008400.0),

--- a/metadatastore/test/test_commands.py
+++ b/metadatastore/test/test_commands.py
@@ -6,6 +6,7 @@ import six
 import uuid
 import time as ttime
 import datetime
+import pytz
 from ..api import Document as Document
 
 from nose.tools import make_decorator
@@ -256,6 +257,55 @@ def test_run_start_custom():
 
     for k in cust:
         assert_equal(getattr(ret, k), cust[k])
+
+
+def _normalize_human_friendly_time_tester(val, should_succeed, etype):
+    if isinstance(val, tuple):
+        (val, check_output) = val
+
+    if should_succeed:
+        output = mdsc._normalize_human_friendly_time(val)
+        assert(isinstance(output, float))
+        try:
+            assert_equal(output, check_output)
+        except NameError:
+            pass
+    else:
+        assert_raises(etype, mdsc._normalize_human_friendly_time, val)
+
+def test_normalize_human_friendly_time():
+    # should get tz from conf?  but no other tests get conf stuff...
+    zone = pytz.timezone('US/Eastern')
+
+    good_test_values = [('2014', 1388552400.0),
+                        ('2014 ', 1388552400.0),  # pandas assumes current month+day
+                        ('2014-02', 1391230800.0),
+                        ('2014-02 ', 1391230800.0),
+                        ('2014-2', 1391230800.0),  # pandas assumes current day
+                        ('2014-2 ', 1391230800.0),  # pandas assumes current day
+                        ('2014-2-10', 1392008400.0),
+                        ('2014-2-10 ', 1392008400.0),
+                        ('2014-02-10', 1392008400.0),
+                        ('2014-02-10 ', 1392008400.0),
+                        (' 2014-02-10 10 ', 1392044400.0),
+                        ('2014-02-10 10:1', 1392044460.0),
+                        ('2014-02-10 10:1 ', 1392044460.0),
+                        ('2014-02-10 10:1:00', 1392044460.0),
+                        ('2014-02-10 10:01:00', 1392044460.0),
+                        ttime.time(),
+                        datetime.datetime.now(),
+                        zone.localize(datetime.datetime.now()),
+                        ]
+    for val in good_test_values:
+        yield _normalize_human_friendly_time_tester, val, True, None
+
+    bad_test_values = ['2015-04-15 03:',
+                       str(ttime.time()),
+                       'aardvark',
+                       ]
+    for val in bad_test_values:
+        yield _normalize_human_friendly_time_tester, val, False, ValueError
+
 
 # smoketests
 


### PR DESCRIPTION
behavior changes from pandas implementation:
- handles tz aware datetime arg
- behaves intuitively in these cases:  '2014 ', '2014-02 ', '2014-2'
  (trailing space, trailing space, no zero pad on month)
  includes fairly comprehensive tests
