### PR TITLE
PRF/API mongoengine speedup

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -358,8 +358,16 @@ class EventDescriptorIsNoneError(ValueError):
 # DATABASE RETRIEVAL ##########################################################
 
 # TODO: Update all query routine documentation
-def _as_document(mongoengine_object):
-    return Document.from_mongo(mongoengine_object)
+class _AsDocument(object):
+    """
+    A caching layer to avoid creating reference objects for _every_
+    """
+    def __init__(self):
+        self._cache = dict()
+
+    def __call__(self, mongoengine_object):
+        return Document.from_mongo(mongoengine_object, self._cache)
+
 
 def _format_time(search_dict):
     """Helper function to format the time arguments in a search dict
@@ -527,7 +535,10 @@ def find_run_starts(**kwargs):
     """
     _normalize_object_id(kwargs, '_id')
     _format_time(kwargs)
+    _as_document = _AsDocument()
+
     rs_objects = RunStart.objects(__raw__=kwargs).order_by('-time')
+    rs_objects = rs_objects.no_dereference()
     return (_as_document(rs) for rs in rs_objects)
 
 
@@ -558,9 +569,11 @@ def find_beamline_configs(**kwargs):
     -------
     beamline_configs : iterable of metadatastore.document.Document objects
     """
+    _as_document = _AsDocument()
     _format_time(kwargs)
     # ordered by _id because it is not guaranteed there will be time in cbonfig
     beamline_configs = BeamlineConfig.objects(__raw__=kwargs).order_by('-_id')
+    beamline_configs = beamline_configs.no_dereference()
     return (_as_document(bc) for bc in beamline_configs)
 
 
@@ -602,6 +615,7 @@ def find_run_stops(**kwargs):
     run_stop : iterable of metadatastore.document.Document objects
     """
     _format_time(kwargs)
+
     try:
         kwargs['run_start_id'] = kwargs.pop('run_start').id
     except KeyError:
@@ -609,6 +623,10 @@ def find_run_stops(**kwargs):
     _normalize_object_id(kwargs, '_id')
     _normalize_object_id(kwargs, 'run_start_id')
     run_stop = RunStop.objects(__raw__=kwargs).order_by('-time')
+    run_stop = run_stop.no_dereference()
+
+    _as_document = _AsDocument()
+
     return (_as_document(rs) for rs in run_stop)
 
 
@@ -646,7 +664,7 @@ def find_event_descriptors(**kwargs):
     event_descriptor : iterable of metadatastore.document.Document objects
     """
     _format_time(kwargs)
-    event_descriptor_list = list()
+    _as_document = _AsDocument()
     try:
         kwargs['run_start_id'] = kwargs.pop('run_start').id
     except KeyError:
@@ -654,9 +672,12 @@ def find_event_descriptors(**kwargs):
     _normalize_object_id(kwargs, '_id')
     _normalize_object_id(kwargs, 'run_start_id')
     event_descriptor_objects = EventDescriptor.objects(__raw__=kwargs)
+
+    event_descriptor_objects = event_descriptor_objects.no_dereference()
     for event_descriptor in event_descriptor_objects.order_by('-time'):
         event_descriptor = _replace_descriptor_data_key_dots(event_descriptor,
                                                              direction='out')
+        print("EVENT DESCIRPTOR", event_descriptor.id)
         yield _as_document(event_descriptor)
 
 
@@ -707,6 +728,8 @@ def find_events(**kwargs):
     _normalize_object_id(kwargs, '_id')
     _normalize_object_id(kwargs, 'descriptor_id')
     events = Event.objects(__raw__=kwargs).order_by('-time')
+    events = events.no_dereference()
+    _as_document = _AsDocument()
     return (reorganize_event(_as_document(ev)) for ev in events)
 
 
@@ -724,6 +747,7 @@ def find_last(num=1):
     run_start: iterable of metadatastore.document.Document objects
     """
     c = count()
+    _as_document = _AsDocument()
     for rs in RunStart.objects.order_by('-time'):
         if next(c) == num:
             raise StopIteration

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -843,6 +843,6 @@ def reorganize_event(event_document):
     event_document
     """
     doc = event_document  # for brevity
-    pairs  = [((k, v[0]), (k, v[1])) for k, v in six.iteritems(doc.data)]
+    pairs = [((k, v[0]), (k, v[1])) for k, v in six.iteritems(doc.data)]
     doc.data, doc.timestamps = [dict(tuples) for tuples in zip(*pairs)]
     return doc

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -689,7 +689,6 @@ def find_event_descriptors(**kwargs):
     for event_descriptor in event_descriptor_objects.order_by('-time'):
         event_descriptor = _replace_descriptor_data_key_dots(event_descriptor,
                                                              direction='out')
-        print("EVENT DESCIRPTOR", event_descriptor.id)
         yield _as_document(event_descriptor)
 
 

--- a/metadatastore/document.py
+++ b/metadatastore/document.py
@@ -133,10 +133,10 @@ class Document(MutableMapping):
                 attr = _normalize(attr, cache)
 
             document[field] = attr
-            # For debugging, add a human-friendly time_as_datetime attribute.
-            if 'time' in document:
-                document.time_as_datetime = datetime.fromtimestamp(
-                        document.time)
+        # For debugging, add a human-friendly time_as_datetime attribute.
+        if 'time' in document:
+            document.time_as_datetime = datetime.fromtimestamp(
+                    document.time)
         return document
 
     def __repr__(self):

--- a/metadatastore/test/test_commands.py
+++ b/metadatastore/test/test_commands.py
@@ -55,6 +55,7 @@ def _ev_desc_tester(run_start, data_keys, time):
                                            data_keys, time)
     q_ret, = mdsc.find_event_descriptors(run_start=run_start)
     ret = EventDescriptor.objects.get(run_start_id=run_start.id)
+    ret.select_related()
     assert_equal(bson.ObjectId(q_ret.id), ret.id)
     q_ret2, = mdsc.find_event_descriptors(_id=ev_desc.id)
     assert_equal(bson.ObjectId(q_ret2.id), ev_desc.id)
@@ -104,8 +105,8 @@ def test_ev_desc():
 
 @raises(mdsc.EventDescriptorIsNoneError)
 def test_ev_insert_fail():
-
     mdsc.insert_event(None, ttime.time(), data={'key': [0, 0]}, seq_num=0)
+
 
 @raises(ValueError)
 def test_proper_data_format():

--- a/metadatastore/test/test_commands.py
+++ b/metadatastore/test/test_commands.py
@@ -3,18 +3,16 @@ from __future__ import (absolute_import, division, print_function,
 
 import bson
 import six
-import uuid
 import time as ttime
 import datetime
 import pytz
 from ..api import Document as Document
 
-from nose.tools import make_decorator
 from nose.tools import assert_equal, assert_raises, raises
 
 
 from metadatastore.odm_templates import (BeamlineConfig, EventDescriptor,
-                                         Event, RunStart, RunStop)
+                                         RunStart, RunStop)
 import metadatastore.commands as mdsc
 from metadatastore.utils.testing import mds_setup, mds_teardown
 from metadatastore.examples.sample_data import temperature_ramp
@@ -76,7 +74,8 @@ def _ev_desc_tester(run_start, data_keys, time):
     mdsc.find_event_descriptors(run_start_id=str(run_start.id))
     mdsc.find_event_descriptors(start_time=ttime.time())
     mdsc.find_event_descriptors(stop_time=ttime.time())
-    mdsc.find_event_descriptors(start_time=ttime.time() - 1, stop_time=ttime.time())
+    mdsc.find_event_descriptors(start_time=ttime.time() - 1,
+                                stop_time=ttime.time())
     mdsc.find_event_descriptors(uid='foo')
     mdsc.find_event_descriptors(_id=ev_desc.id)
     mdsc.find_event_descriptors(_id=str(ev_desc.id))
@@ -102,13 +101,15 @@ def test_ev_desc():
     time = ttime.time()
     yield _ev_desc_tester, rs, data_keys, time
 
+
 @raises(mdsc.EventDescriptorIsNoneError)
 def test_ev_insert_fail():
-    ev = mdsc.insert_event(None, ttime.time(), data={'key': [0, 0]}, seq_num=0)
+
+    mdsc.insert_event(None, ttime.time(), data={'key': [0, 0]}, seq_num=0)
 
 @raises(ValueError)
 def test_proper_data_format():
-    data = {'key': [15,]}
+    data = {'key': [15, ]}
     mdsc._validate_data(data)
 
 


### PR DESCRIPTION
Don't re-build the EventDescriptor and DataKeys documents for every event.

A subtle API change is that now all of the events for the same event descriptor share the same python object of that descriptor if they are returned from the same call to `find/fetch_events`
