### PR TITLE
API : restore id on event documents

### DIFF
--- a/metadatastore/document.py
+++ b/metadatastore/document.py
@@ -175,6 +175,7 @@ class Document(MutableMapping):
         document._name = name
         for k, v in six.iteritems(input_dict):
             if k == '_id':
+                document['id'] = str(v)
                 continue
             if isinstance(v, ObjectId):
                 ref_klass = dref_fields[k]


### PR DESCRIPTION
Turns out the value of `_id` is leaking out and being used
elsewhere in the stack.  Restore this to un-break the API.
