### PR TITLE
Refactor document printing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - conda create -n testenv --yes pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas
   - conda install -n testenv --yes -c nikea mongoengine
   - source activate testenv
-  - pip install coveralls
+  - pip install coveralls prettytable
   - python setup.py install
 
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - mongoengine
     - six
     - pyyaml
+    - prettytable
 
 test:
   requires:

--- a/example/synthetic_cosine.py
+++ b/example/synthetic_cosine.py
@@ -22,7 +22,7 @@ data_keys = {'linear_motor': {'source': 'PV:pv1',
              }
 
 try:
-    last_hdr = find_last()[0]
+    last_hdr = next(find_last())
     scan_id = int(last_hdr.scan_id)+1
 except (IndexError, TypeError):
     scan_id = 1
@@ -49,7 +49,7 @@ for idx, i in enumerate(np.linspace(start, stop, num)):
     e = insert_event(event_descriptor=e_desc, seq_num=idx,
                      time=time.time(),
                      data=data)
-last_run = find_last()[0]
+last_run = next(find_last())
 try:
     if str(last_run.id) != str(rs.id):
         print("find_last() is broken")

--- a/metadatastore/document.py
+++ b/metadatastore/document.py
@@ -7,7 +7,7 @@ from bson.dbref import DBRef
 from datetime import datetime
 from itertools import chain
 from collections import MutableMapping
-import prettytable
+from prettytable import PrettyTable
 
 def _normalize(in_val, cache):
     """
@@ -215,13 +215,7 @@ class Document(MutableMapping):
                 for val in value:
                     documents.append((name, val))
             elif name == 'data_keys':
-                for data_name, data_document in six.iteritems(value):
-                    ret += "\n%s" % data_document._str_helper(data_name, indent+1, max_indent=2)
-                    # ret += '\n%s\n%s' % (data_name,
-                    #                      mapping[indent]*len(data_name))
-                    # for k, v, in six.iteritems(data_document):
-                    #     ret += "\n\t%-9s: %-40s" % (k, v)
-                    # pass
+                ret += "\n%s" % _prettytable(value).__str__()
             else:
                 ret += "\n%-15s: %-40s" % (name[:15], value)
         for name, value in documents:
@@ -236,6 +230,20 @@ class Document(MutableMapping):
         return self._str_helper(self._name)
 
     __repr__ = __str__
+
+
+def _prettytable(data_keys_dict):
+    fields = data_keys_dict.values()[0]._fields
+    table = PrettyTable(["key name"] + list(fields))
+    table.align['key name'] = 'l'
+    table.padding_width = 1
+    for data_key, key_dict in sorted(data_keys_dict.items()):
+        row = [data_key]
+        for k, v in sorted(key_dict.items()):
+            row.append(v)
+        table.add_row(row)
+    return table
+
 
 if __name__ == "__main__":
     from dataportal import DataBroker as db

--- a/metadatastore/document.py
+++ b/metadatastore/document.py
@@ -198,10 +198,34 @@ class Document(MutableMapping):
                 document.time)
         return document
 
-    # def __repr__(self):
-    #     return "<{0} Document>".format(self._name)
+    def __repr__(self):
+        return "<{0} Document>".format(self._name)
 
-    def _str_helper(self, name, indent=0, max_indent=1):
+    def _str_helper(self, name=None, indent=0, max_indent=1):
+        """Recursive document walker and formatter
+
+        Parameters
+        ----------
+        name : str, optional
+            Document header name. Defaults to ``self._name``
+        indent : int, optional
+            The indentation level. Defaults to starting at 0 and adding one tab
+            per recursion level
+        max_indent : int, optional
+            The maximum number of document levels to recurse into.  For printing
+            a header,
+
+        Note
+        ----
+        max_indent should be set to 1 for printing a header. If it is not
+        set to 1, then the return value for _str_helper will be:
+
+        Header
+          - Event Descriptor
+            - Run Start
+
+        ...which is dumb.
+        """
         if indent > max_indent:
             return ''
         mapping = {0: '-', 1: '=', 2: '~'}

--- a/metadatastore/document.py
+++ b/metadatastore/document.py
@@ -241,7 +241,7 @@ class Document(MutableMapping):
             elif name == 'data_keys':
                 ret += "\n%s" % _prettytable(value).__str__()
             else:
-                ret += "\n%-15s: %-40s" % (name[:15], value)
+                ret += "\n%-16s: %-40s" % (name[:16], value)
         for name, value in documents:
             ret += "\n%s" % (value._str_helper(value._name, indent+1))
             # ret += "\n"

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     author='Arkilic',
     author_email=None,
     license="BSD (3-clause)",
-    url = "https://github.com/NSLS-II/metadatastore",
+    url="https://github.com/NSLS-II/metadatastore",
     packages=['metadatastore', 'metadatastore.test', 'metadatastore.utils',
               'metadatastore.examples', 'metadatastore.examples.sample_data'],
     long_description=read('README.md'),


### PR DESCRIPTION
Recursively print the Document class and format the DataKeys of an EventDescriptor into a table. 
## Example header output

``` python
from dataportal import DataBroker as db
print(db[-1])
```

produces

```
Header
------
beamline_id    : csx                                     
group          :                                         
moon           : full                                    
owner          :                                         
plotx          : linear_motor                            
ploty          : [u'total_img_sum']                      
project        :                                         
run_start_id   : 5538f65f3892c9066bf8917a                
run_start_uid  : 5a84b162-126b-449b-b00a-c2b506c9619e    
sample         : {}                                      
scan_id        : 36                                      
start_datetime : 2015-04-23 09:40:47.857965              
start_time     : 1429796447.86                           

  BeamlineConfig
  ==============
  config_params  : {u'my_beamline': u'my_value'}           
  id             : 5538f65f3892c9066bf89179                
  time           : 1429796447.84                           
  time_as_datetim: 2015-04-23 09:40:47.835954              
  uid            : 8990e097-000c-4592-841d-3dcdfc04bb88    

  EventDescriptor
  ===============
  +---------------+--------+------------+----------+-------------+
  | key name      | dtype  |   shape    | external |    source   |
  +---------------+--------+------------+----------+-------------+
  | img           | array  | FILESTORE: |  [5, 5]  |     CCD     |
  | img_sum_x     | array  | FILESTORE: |   [5]    |   CCD:xsum  |
  | img_sum_y     | array  | FILESTORE: |   [5]    |   CCD:ysum  |
  | img_x_max     | number |    None    |    []    |   CCD:xmax  |
  | img_y_max     | number |    None    |    []    |   CCD:ymax  |
  | linear_motor  | number |    None    |    []    | PV:ES:sam_x |
  | total_img_sum | number |    None    |    []    |   CCD:sum   |
  +---------------+--------+------------+----------+-------------+
  id             : 5538f65f3892c9066bf8917b                
  time           : 0.0                                     
  time_as_datetim: 1969-12-31 19:00:00                     
  uid            : 5f6559a2-f643-4ce8-9615-43538ddf0e71    


  EventDescriptor
  ===============
  +----------+--------+-------+----------+------------+
  | key name | dtype  | shape | external |   source   |
  +----------+--------+-------+----------+------------+
  | Tsam     | number |  None |    []    | PV:ES:Tsam |
  +----------+--------+-------+----------+------------+
  id             : 5538f65f3892c9066bf8917c                
  time           : 0.0                                     
  time_as_datetim: 1969-12-31 19:00:00                     
  uid            : 2aa492c6-072d-4de0-a5ea-8c87dffcdb4f    
```
