### PR TITLE
ENH: Add count_events, a stopgap.

### DIFF
--- a/metadatastore/api.py
+++ b/metadatastore/api.py
@@ -1,7 +1,7 @@
 # Data retrieval
 from .commands import (find_events, find_event_descriptors,
                        find_beamline_configs, find_run_starts, find_last,
-                       find_run_stops)
+                       find_run_stops, count_events)
 # Data insertion
 from .commands import (insert_event, insert_event_descriptor, insert_run_start,
                        insert_beamline_config, insert_run_stop,

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -638,6 +638,29 @@ def find_events(**kwargs):
 
 
 @_ensure_connection
+def count_events(**kwargs):
+    """Like find_events, but it returns the count, not the actual Events.
+
+    This function is likely to be deprecated in this near future. Instead,
+    find_events will return an iterator that has a length.
+    """
+    # Some user-friendly error messages for an easy mistake to make
+    if 'event_descriptor' in kwargs:
+        raise ValueError("Use 'descriptor', not 'event_descriptor'.")
+    if 'event_descriptor_id' in kwargs:
+        raise ValueError("Use 'descriptor_id', not 'event_descriptor_id'.")
+
+    _format_time(kwargs)
+    try:
+        kwargs['descriptor_id'] = kwargs.pop('descriptor').id
+    except KeyError:
+        pass
+    _normalize_object_id(kwargs, '_id')
+    _normalize_object_id(kwargs, 'descriptor_id')
+    return len(Event.objects(__raw__=kwargs))
+
+
+@_ensure_connection
 def find_last(num=1):
     """Locate the last `num` RunStart Documents
 


### PR DESCRIPTION
Now that `find_events` returns a generator, there is no way to know how many Events are there without looping through them all. This add a new function `count_events` that uses mongo to count the size of the query results without actually building the Event documents.

_This is a temporary solution._ In the long term, it will likely be replaced by one of the following:
- counting each Event stream at the end of a scan and storing those tallies in the RunStop
- making `find_events` return a special pims-like object, a generator that knows its own length
