### PR TITLE
API: Interface to MDS is uids, not mongoengine documents.

### DIFF
--- a/metadatastore/examples/sample_data/temperature_ramp.py
+++ b/metadatastore/examples/sample_data/temperature_ramp.py
@@ -9,7 +9,7 @@ deadband_size = 0.9
 num_exposures = 23
 
 @common.example
-def run(run_start=None, sleep=0):
+def run(run_start_uid=None, sleep=0):
     if sleep != 0:
         raise NotImplementedError("A sleep time is not implemented for this "
                                   "example.")
@@ -22,10 +22,10 @@ def run(run_start=None, sleep=0):
     # Create Event Descriptors
     data_keys1 = {'point_det': dict(source='PV:ES:PointDet', dtype='number')}
     data_keys2 = {'Tsam': dict(source='PV:ES:Tsam', dtype='number')}
-    ev_desc1 = insert_event_descriptor(run_start=run_start,
-                                       data_keys=data_keys1, time=0.)
-    ev_desc2 = insert_event_descriptor(run_start=run_start,
-                                       data_keys=data_keys2, time=0.)
+    ev_desc1_uid = insert_event_descriptor(run_start=run_start_uid,
+                                           data_keys=data_keys1, time=0.)
+    ev_desc2_uid = insert_event_descriptor(run_start=run_start_uid,
+                                           data_keys=data_keys2, time=0.)
 
     # Create Events.
     events = []
@@ -34,16 +34,18 @@ def run(run_start=None, sleep=0):
     for i in range(num_exposures):
         time = float(i + 0.01 * rs.randn())
         data = {'point_det': (point_det_data[i], time)}
-        event = insert_event(event_descriptor=ev_desc1, seq_num=i, time=time,
-                             data=data)
+        event = dict(event_descriptor=ev_desc1_uid, seq_num=i, time=time,
+                 data=data)
+        insert_event(**event)
         events.append(event)
 
     # Temperature Events
     for i, (time, temp) in enumerate(zip(*deadbanded_ramp)):
         time = float(time)
         data = {'Tsam': (temp, time)}
-        event = insert_event(event_descriptor=ev_desc2, time=time,
-                             data=data, seq_num=i)
+        event = dict(event_descriptor=ev_desc2_uid, time=time,
+                     data=data, seq_num=i)
+        insert_event(**event)
         events.append(event)
 
     return events


### PR DESCRIPTION
We are moving toward a model where ophyd builds dictionaries matching the established document spec and emits them to generic consumers. MDS is merely one consumer, and other consumers could be alongside of or in place of it. Thus, the MDS API should not deal in mongoengine documents. It should accept and return uids.

Before:

```
run_start_document = insert_run_start(...)
event_descriptor_document = insert_event_descriptor(run_start_document, ...)
```

After:

```
run_start_uid = insert_run_start(...)
event_descriptor_uid = insert_event_descriptor(run_start_uid, ...)
```

This PR does not touch `odm_templates.py` and therefore does not require a database migration.

More Details:
- The argument for the run start uid is simply `run_start` not `run_start_uid`, so that dictionaries matching the document spec (which has `run_start`, not `run_start_uid`) can be unpacked into the function: `insert_event_descriptor(**my_descriptor_dict)`
