### PR TITLE
FIX: Port is an integer.

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -33,7 +33,7 @@ def _ensure_connection(func):
     def inner(*args, **kwargs):
         database = conf.connection_config['database']
         host = conf.connection_config['host']
-        port = conf.connection_config['port']
+        port = int(conf.connection_config['port'])
         db_connect(database=database, host=host, port=port)
         return func(*args, **kwargs)
     return inner


### PR DESCRIPTION
Without this, setting `MDS_PORT` using an environmental variable doesn't work.
