### PR TITLE
BLD: Set mongoengine version to 0.8.7 in conda recipe.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
   run:
     - python
-    - mongoengine
+    - mongoengine ==0.8.7
     - six
     - pyyaml
     - prettytable


### PR DESCRIPTION
Avoid accidentally upgrading to 0.9 if a 0.9 build is sitting on an accessible conda channel.
