### PR TITLE
MNT: update to deal with API change in ME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ install:
 - conda config --set always_yes true
 - conda update conda --yes
 - conda config --add channels lightsource2
-- conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas jinja2 mongoengine boltons prettytable humanize
+- conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas jinja2 boltons prettytable humanize
 - source activate testenv
+- pip install mongoengine
 - pip install coveralls codecov
 - python setup.py install
 - git describe

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 script:
 - python run_tests.py -v
 - git fetch --unshallow
-- conda install -n root conda-build jinja2 anaconda-client
+- conda install -n root conda-build==1.18.1 jinja2 anaconda-client
 - export CONDA_BUILD_COMMAND="conda build conda-recipe --python=$TRAVIS_PYTHON_VERSION"
 - "$CONDA_BUILD_COMMAND"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 - conda config --set always_yes true
 - conda update conda --yes
 - conda config --add channels lightsource2
-- conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION "pymongo=2.9" six pyyaml numpy pandas jinja2 mongoengine boltons prettytable humanize
+- conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas jinja2 mongoengine boltons prettytable humanize
 - source activate testenv
 - pip install coveralls codecov
 - python setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
 
   run:
     - python
-    - mongoengine ==0.8.7
-    - pymongo ==2.9
+    - mongoengine
+    - pymongo
     - six
     - pyyaml
     - prettytable

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -773,7 +773,7 @@ def insert_event(descriptor, time, seq_num, data, timestamps, uid):
     # get the ObjectID so for reference field
     desc_oid = _DESCRIPTOR_UID_to_OID_MAP[descriptor_uid]
     # create the Event document
-    event = Event(descriptor_id=desc_oid, uid=uid,
+    event = Event(descriptor=desc_oid, uid=uid,
                   data=val_ts_tuple, time=time, seq_num=seq_num)
 
     event.save(validate=True, write_concern={"w": 1})


### PR DESCRIPTION
This allows our code to work with ME current-master and
pymongo v3

There is a bug in v0.10.0 & pymongo 3 due to a renaming of
`disconnect` -> `close` on pymongo collections.

This should not be merged until we have a plan to roll out ME/pymongo updates.

We should probably do this soon as there is a 2x speed up on read speed due to going from pymongo 2.8 -> 3.0.
