### PR TITLE
API: rename get_event_* -> fetch_event_*

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -443,7 +443,7 @@ def descriptors_by_start(run_start):
 
 
 @_ensure_connection
-def fetch_events_generator(descriptor):
+def get_events_generator(descriptor):
     """A generator which yields all events from the event stream
 
     Parameters
@@ -514,7 +514,7 @@ def _transpose(in_data, keys, field):
 
 
 @_ensure_connection
-def fetch_events_table(descriptor):
+def get_events_table(descriptor):
     """All event data as tables
 
     Parameters
@@ -542,7 +542,7 @@ def fetch_events_table(descriptor):
     desc_uid = doc_or_uid_to_uid(descriptor)
     descriptor = descriptor_given_uid(desc_uid)
     # this will get more complicated once transpose caching layer is in place
-    all_events = list(fetch_events_generator(desc_uid))
+    all_events = list(get_events_generator(desc_uid))
 
     # get event sequence numbers
     seq_nums = [ev['seq_num'] for ev in all_events]

--- a/metadatastore/test/test_commands.py
+++ b/metadatastore/test/test_commands.py
@@ -340,7 +340,7 @@ def test_bulk_insert():
     mdsc.bulk_insert_events(e_desc, all_data, validate=False)
     mdsc.insert_run_stop(rs, ttime.time(), uid=str(uuid.uuid4()))
 
-    ev_gen = mdsc.fetch_events_generator(e_desc)
+    ev_gen = mdsc.get_events_generator(e_desc)
 
     for ret, expt in zip(ev_gen, all_data):
         assert_equal(ret['descriptor']['uid'], e_desc)
@@ -355,7 +355,7 @@ def test_bulk_table():
 
     mdsc.bulk_insert_events(e_desc, all_data, validate=False)
     mdsc.insert_run_stop(rs, ttime.time(), uid=str(uuid.uuid4()))
-    ret = mdsc.fetch_events_table(e_desc)
+    ret = mdsc.get_events_table(e_desc)
     descriptor, data_table, seq_nums, times, uids, timestamps_table = ret
 
     for vals in data_table.values():


### PR DESCRIPTION
Change to match naming in dataportal and conventional DB verbiage
