### PR TITLE
Add 'scan_type' to run start.

### DIFF
--- a/metadatastore/examples/sample_data/common.py
+++ b/metadatastore/examples/sample_data/common.py
@@ -80,7 +80,8 @@ def example(func):
         if run_start_uid is None:
             run_start_uid = insert_run_start(time=get_time(), scan_id=1,
                                            beamline_id='example',
-                                           uid=str(uuid.uuid4()))
+                                           uid=str(uuid.uuid4()),
+                                           scan_type=func.__name__)
 
         # these events are already the sanitized version, not raw mongo objects
         events = func(run_start_uid, sleep)

--- a/metadatastore/examples/sample_data/common.py
+++ b/metadatastore/examples/sample_data/common.py
@@ -78,10 +78,13 @@ def example(func):
     @wraps(func)
     def mock_run_start(run_start_uid=None, sleep=0, make_run_stop=True):
         if run_start_uid is None:
+            # grab the module name; this is a helpful indication of the "scan"
+            func_name = func.__module__.split('.')[-1]
+            custom = {'scan_type': func_name}
             run_start_uid = insert_run_start(time=get_time(), scan_id=1,
-                                           beamline_id='example',
-                                           uid=str(uuid.uuid4()),
-                                           scan_type=func.__name__)
+                                             beamline_id='example',
+                                             uid=str(uuid.uuid4()),
+                                             custom=custom)
 
         # these events are already the sanitized version, not raw mongo objects
         events = func(run_start_uid, sleep)

--- a/metadatastore/examples/sample_data/multisource_event.py
+++ b/metadatastore/examples/sample_data/multisource_event.py
@@ -67,13 +67,15 @@ def run(run_start=None, sleep=0):
 
 if __name__ == '__main__':
     import metadatastore.api as mdsc
+    custom = {'scan_type': 'Multisource Event'}
     run_start_uid = mdsc.insert_run_start(scan_id=2032013,
                                           beamline_id='testbed',
                                           owner='tester',
                                           group='awesome-devs',
                                           project='Nikea',
                                           time=0.,
-                                          uid=str(uuid.uuid4()),)
+                                          uid=str(uuid.uuid4()),
+                                          custom=custom)
 
     print('run_start_uid = %s' % run_start_uid)
     run(run_start_uid)

--- a/metadatastore/examples/sample_data/temperature_ramp.py
+++ b/metadatastore/examples/sample_data/temperature_ramp.py
@@ -70,14 +70,15 @@ def run(run_start_uid=None, sleep=0):
 
 if __name__ == '__main__':
     import metadatastore.api as mdsc
-
+    custom = {'scan_type': 'Temperature Ramp'}
     run_start_uid = mdsc.insert_run_start(scan_id=3022013,
                                           beamline_id='testbed',
                                           owner='tester',
                                           group='awesome-devs',
                                           project='Nikea',
                                           time=common.get_time(),
-                                          uid=str(uuid.uuid4()))
+                                          uid=str(uuid.uuid4()),
+                                          custom=custom)
 
     print('run_start_uid = %s' % run_start_uid)
     run(run_start_uid)


### PR DESCRIPTION
I want this in the run start because it is getting put in by bluesky.
It is pretty helpful to have the same info in the sample data generators that
we expect to be in the actual experimental data.  The next step would be to
add 'scan_args' to the run start too.
