### PR TITLE
Upload to anaconda.org/lightsource2-dev from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,7 @@ after_success:
 - source deactivate
 - git clone https://github.com/ericdill/travis-little-helper
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" == "master" ]; then
-    $CONDA_BUILD_COMMAND --output | bash travis-little-helper/anaconda-version-string.sh > version;
-    anaconda login --username nsls2builder --password $ANACONDA_PASS --hostname "$TRAVIS_PYTHON_VERSION-`cat version`";
-    bash travis-little-helper/clean-anaconda-channel.sh lightsource2-dev metadatastore true;
-    anaconda upload -u lightsource2-dev `$CONDA_BUILD_COMMAND --output`;
-    anaconda logout;
+    bash travis-little-helper clean_and_upload.sh "$CONDA_BUILD_COMMAND --output" nsls2builder $ANACONDA_PASS "$TRAVIS_PYTHON_VERSION-`cat version`" lightsource2-dev metadatastore
   fi;
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
 - source activate testenv
 - pip install coveralls codecov
 - python setup.py install
+- git describe
+- python -c "import metadatastore; print(metadatastore.__version__)"
 script:
 - python run_tests.py -v
 - git fetch --unshallow

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,15 +43,12 @@ after_success:
 - source deactivate
 # see if we are on the master branch. if so, upload the new build.
 - git clone https://github.com/ericdill/travis-little-helper
-- ls
-- ls travis-little-helper
-- which bash
-- pwd
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     $CONDA_BUILD_COMMAND --output | bash travis-little-helper/anaconda-version-string.sh > version;
+    anaconda login --username $USER --password $PASS --hostname "$TRAVIS_PYTHON_VERSION-`cat version`";
     bash travis-little-helper/clean-anaconda-channel.sh lightsource2-dev metadatastore true;
-    anaconda login --username $USER --password $PASS;
     anaconda upload -u lightsource2-dev `$CONDA_BUILD_COMMAND --output`;
+    anaconda logout;
   fi;
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 - python run_tests.py -v
 - git fetch --unshallow
 - conda install -n root conda-build jinja2 anaconda-client
-- conda build conda-recipe
+- conda build conda-recipe --python=$TRAVIS_PYTHON_VERSION
 after_success:
 - coveralls
 - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ matrix:
   - python: 3.4
   - python: 3.5
 before_install:
-- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh
-  -O miniconda.sh; fi
+- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
+    wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh;
+  else
+    wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh;
+  fi;
 - chmod +x miniconda.sh
 - "./miniconda.sh -b -p /home/travis/mc"
 - export PATH=/home/travis/mc/bin:$PATH
@@ -24,8 +26,7 @@ install:
 - conda config --set always_yes true
 - conda update conda --yes
 - conda config --add channels lightsource2
-- conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION "pymongo=2.9" six
-  pyyaml numpy pandas jinja2 mongoengine boltons prettytable humanize
+- conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION "pymongo=2.9" six pyyaml numpy pandas jinja2 mongoengine boltons prettytable humanize
 - source activate testenv
 - pip install coveralls codecov
 - python setup.py install
@@ -36,13 +37,13 @@ script:
 - git fetch --unshallow
 - conda install -n root conda-build jinja2 anaconda-client
 - export CONDA_BUILD_COMMAND="conda build conda-recipe --python=$TRAVIS_PYTHON_VERSION"
-- $CONDA_BUILD_COMMAND
+- "$CONDA_BUILD_COMMAND"
 after_success:
 - coveralls
 - codecov
 - source deactivate
-# see if we are on the master branch. if so, upload the new build.
 - git clone https://github.com/ericdill/travis-little-helper
+
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     $CONDA_BUILD_COMMAND --output | bash travis-little-helper/anaconda-version-string.sh > version;
     anaconda login --username $USER --password $PASS --hostname "$TRAVIS_PYTHON_VERSION-`cat version`";
@@ -52,5 +53,6 @@ after_success:
   fi;
 env:
   global:
-  - secure: o3XFQlwLvStOPXjbpwdIgs7+Tn9d0flcTGGnFsWHrt7/duam6I7prMRy/ItZXHHTPayvSeC8P302gU/kygGQ347P8+nZts5dZMJAx9ngOsTFtawEqM20V/uH6ESG1hVO88sf1T9JIR/nlMl/DYYuijv0bomtsIBp0m+vuxHBsAU=
-  - secure: EKFAmc1vJ/P9wwLhbd948iEm1PIlgARmip6i7pwbsHwum1Ze5qXHqwbOYsc6qN40f5K2Q5N5oOXCgTA7M9ZITme164NVe3irJoLUuG+C+O7zlDgwkUDb/s+qHieGf/hK8gRpe8dtTHpod/oE9bBpawlxNoBQXeecp5k91WvGRiE=
+    secure: "Fu8j9IR5+1dSNI20MEJbnPzz8bEvkchYw5NpDPnE2LhYNI+5F9FfXp0gDv79w10kkp+sBZFvm6lEzv/u7inryySBLy/Oi0XvjO6BWf6cYsHcLmfIzyGMVhWQC8Rt2SMvJlDaEwpEOIlm/7x+ME5LnXj5yU9Ixvnk51kQa5QjOUs="
+    secure: "KZycohzXLRIkfYpKo35p8jGBH4dozQP0CYR3cu/h2CoBWMu2UsNsMx6mW1ZDWbr6dWCMZhC7pui+8K2RF5tgT97L/DHOzEhzuhjrcBWiJTKo2oGAMEUeeaLgUXynfhOZAg4pgXZAdtbtLQ7EwAu7eXID3Z4Nd2H2t9NUk690Fmk="
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,14 @@ after_success:
 - codecov
 - source deactivate
 # see if we are on the master branch. if so, upload the new build.
+- git clone https://github.com/ericdill/travis-little-helper
+- ls
+- ls travis-little-helper
+- which bash
+- pwd
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+    $CONDA_BUILD_COMMAND --output | bash travis-little-helper/anaconda-version-string.sh > version;
+    bash travis-little-helper/clean-anaconda-channel.sh lightsource2-dev metadatastore true;
     anaconda login --username $USER --password $PASS;
     anaconda upload -u lightsource2-dev `$CONDA_BUILD_COMMAND --output`;
   fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ script:
 - python run_tests.py -v
 - git fetch --unshallow
 - conda install -n root conda-build jinja2 anaconda-client
-- conda build conda-recipe --python=$TRAVIS_PYTHON_VERSION
+- export CONDA_BUILD_COMMAND="conda build conda-recipe --python=$TRAVIS_PYTHON_VERSION"
+- $CONDA_BUILD_COMMAND
 after_success:
 - coveralls
 - codecov
@@ -41,7 +42,7 @@ after_success:
 # see if we are on the master branch. if so, upload the new build.
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     anaconda login --username $USER --password $PASS;
-    anaconda upload -u lightsource2-dev `conda build conda-recipe --output`;
+    anaconda upload -u lightsource2-dev `$CONDA_BUILD_COMMAND --output`;
   fi;
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
   - python: 3.4
   - python: 3.5
 before_install:
-- echo "ANACONDA_USER=$ANACONDA_USER"
-- echo "ANACONDA_PASS=$ANACONDA_PASS"
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - chmod +x miniconda.sh
 - "./miniconda.sh -b -p /home/travis/mc"
@@ -41,7 +39,7 @@ after_success:
 - codecov
 - source deactivate
 - git clone https://github.com/ericdill/travis-little-helper
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+- if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" == "master" ]; then
     $CONDA_BUILD_COMMAND --output | bash travis-little-helper/anaconda-version-string.sh > version;
     anaconda login --username nsls2builder --password $ANACONDA_PASS --hostname "$TRAVIS_PYTHON_VERSION-`cat version`";
     bash travis-little-helper/clean-anaconda-channel.sh lightsource2-dev metadatastore true;
@@ -51,4 +49,3 @@ after_success:
 env:
   global:
     secure: "pYO9aM4keSwyVrom3/tbmjE0mwuSBKJ+SroIF56JUVLh8jT3jiHmwZfI3fUNY6erNewyoiFhkDDBvyY/gxXGHma6T0RcV+LAZmWCXePBL8fsm5X93lo3RlPFtqmXbkOW7C0+h4RDEMQP/UYsNJvL7YbmeDT+fNozV/CpK1zJtU4="
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ matrix:
   - python: 3.4
   - python: 3.5
 before_install:
-- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-    wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh;
-  else
-    wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh;
-  fi;
+- echo "ANACONDA_USER=$ANACONDA_USER"
+- echo "ANACONDA_PASS=$ANACONDA_PASS"
+- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - chmod +x miniconda.sh
 - "./miniconda.sh -b -p /home/travis/mc"
 - export PATH=/home/travis/mc/bin:$PATH
@@ -43,16 +41,14 @@ after_success:
 - codecov
 - source deactivate
 - git clone https://github.com/ericdill/travis-little-helper
-
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     $CONDA_BUILD_COMMAND --output | bash travis-little-helper/anaconda-version-string.sh > version;
-    anaconda login --username $USER --password $PASS --hostname "$TRAVIS_PYTHON_VERSION-`cat version`";
+    anaconda login --username nsls2builder --password $ANACONDA_PASS --hostname "$TRAVIS_PYTHON_VERSION-`cat version`";
     bash travis-little-helper/clean-anaconda-channel.sh lightsource2-dev metadatastore true;
     anaconda upload -u lightsource2-dev `$CONDA_BUILD_COMMAND --output`;
     anaconda logout;
   fi;
 env:
   global:
-    secure: "Fu8j9IR5+1dSNI20MEJbnPzz8bEvkchYw5NpDPnE2LhYNI+5F9FfXp0gDv79w10kkp+sBZFvm6lEzv/u7inryySBLy/Oi0XvjO6BWf6cYsHcLmfIzyGMVhWQC8Rt2SMvJlDaEwpEOIlm/7x+ME5LnXj5yU9Ixvnk51kQa5QjOUs="
-    secure: "KZycohzXLRIkfYpKo35p8jGBH4dozQP0CYR3cu/h2CoBWMu2UsNsMx6mW1ZDWbr6dWCMZhC7pui+8K2RF5tgT97L/DHOzEhzuhjrcBWiJTKo2oGAMEUeeaLgUXynfhOZAg4pgXZAdtbtLQ7EwAu7eXID3Z4Nd2H2t9NUk690Fmk="
+    secure: "pYO9aM4keSwyVrom3/tbmjE0mwuSBKJ+SroIF56JUVLh8jT3jiHmwZfI3fUNY6erNewyoiFhkDDBvyY/gxXGHma6T0RcV+LAZmWCXePBL8fsm5X93lo3RlPFtqmXbkOW7C0+h4RDEMQP/UYsNJvL7YbmeDT+fNozV/CpK1zJtU4="
 


### PR DESCRIPTION
Hooray it works!

Here's what happens:
1. set up travis environment for metadatastore
2. execute `run_tests.py`
3. execute `conda build conda-recipe`
   if tests pass then:
4. clone some bash scripts from ericdill/travis-little-helper that:
   
   A. determines the exact version of the conda binary 
   B. removes all packages from the lightsource2-dev/metadatastore channel that do not match the version in A.
5. upload the binary built on travis to lightsource2-dev/metadatastore
