### PR TITLE
FIX: only convert directly stored array to ndarray

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -466,7 +466,7 @@ def get_events_generator(descriptor):
     col = Event._get_collection()
     ev_cur = col.find({'descriptor_id': oid},
                       sort=[('time', 1)])
-
+    data_keys = descriptor['data_keys']
     for ev in ev_cur:
         # ditch the ObjectID
         del ev['_id']
@@ -478,7 +478,9 @@ def get_events_generator(descriptor):
         ev['timestamps'] = {k: v[1] for k, v in data.items()}
         ev['data'] = {k: v[0] for k, v in data.items()}
         for k, v in ev['data'].items():
-            if descriptor['data_keys'][k]['dtype'] == 'array':
+            _dk = data_keys[k]
+            # convert any arrays stored directly in mds into ndarray
+            if _dk['dtype'] == 'array' and not _dk.get('external', False):
                 ev['data'][k] = np.asarray(ev['data'][k])
         # wrap it in our fancy dict
         ev = doc.Document('Event', ev)


### PR DESCRIPTION
The uids from filestore were being converted to 1 element object arrays
which were failing when handed back to filestore.

attn @imrealkaren
