### PR TITLE
MNT: Sort events so oldest is first

### DIFF
--- a/metadatastore/core.py
+++ b/metadatastore/core.py
@@ -1007,7 +1007,7 @@ def find_events(start_col, start_cache,
 
     _format_time(kwargs, tz)
     col = event_col
-    events = col.find(kwargs)
+    events = col.find(kwargs, sort=[('time', pymongo.ASCENDING)])
 
     for ev in events:
         ev.pop('_id', None)


### PR DESCRIPTION
Fixes the problem where events are returned newest first. This causes issues in suitcase.

https://gist.github.com/ericdill/11c77848fee4725efdef2a9d4e2fc2c6
