### PR TITLE
ENH: Add generic insert dispatcher.

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -212,6 +212,28 @@ def get_events_table(descriptor):
 
 # database INSERTION ###################################################
 
+
+def insert(name, doc, validate=False):
+    """
+    Insert a document or bulk event documents.
+
+    Dispatches to the other insert functions.
+
+    Parameters
+    ----------
+    name : {'start', 'stop', 'event', 'descriptor', 'bulk_events'}
+    doc : dict-like
+        either a document or, for bulk events, a dict mapping descriptor
+        uids to lists of event documents
+
+    Returns
+    -------
+    result : str or dict
+        See docstrings of other ``insert_*`` functions.
+    """
+    return _DB_SINGLETON.insert(name, doc, validate=validate)
+
+
 def insert_run_start(time, scan_id, beamline_id, uid, owner='', group='',
                      project='', **kwargs):
     """Insert a RunStart document into the database.

--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -213,7 +213,7 @@ def get_events_table(descriptor):
 # database INSERTION ###################################################
 
 
-def insert(name, doc, validate=False):
+def insert(name, doc):
     """
     Insert a document or bulk event documents.
 
@@ -231,7 +231,7 @@ def insert(name, doc, validate=False):
     result : str or dict
         See docstrings of other ``insert_*`` functions.
     """
-    return _DB_SINGLETON.insert(name, doc, validate=validate)
+    return _DB_SINGLETON.insert(name, doc)
 
 
 def insert_run_start(time, scan_id, beamline_id, uid, owner='', group='',

--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -669,12 +669,12 @@ class MDS(MDSRO):
                                        events=events,
                                        validate=validate)
 
-    def insert(self, name, doc, validate=False):
+    def insert(self, name, doc):
         if name != 'bulk_events':
-            getattr(self, self._INS_METHODS[name])(validate=validate, **doc)
+            getattr(self, self._INS_METHODS[name])(**doc)
         else:
             for desc_uid, events in doc.items():
                 # If events is empty, mongo chokes.
                 if not events:
                     continue
-                self.bulk_insert_events(desc_uid, events, validate=validate)
+                self.bulk_insert_events(desc_uid, events)

--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -501,14 +501,11 @@ class MDSRO(object):
 
 
 class MDS(MDSRO):
-    def __init__(self, *args, **kwargs):
-        self.__doc__ = super().__init__.__doc__
-        super().__init__(*args, **kwargs)
-        self._INS_METHODS = {'start': self.insert_run_start,
-                             'stop': self.insert_run_stop,
-                             'descriptor': self.insert_descriptor,
-                             'event': self.insert_event,
-                             'bulk_events': self.bulk_insert_events}
+    _INS_METHODS = {'start': 'insert_run_start',
+                    'stop': 'insert_run_stop',
+                    'descriptor': 'insert_descriptor',
+                    'event': 'insert_event',
+                    'bulk_events': 'bulk_insert_events'}
 
     def insert_run_start(self, time, scan_id, beamline_id, uid,
                          owner='', group='', project='', **kwargs):
@@ -674,7 +671,7 @@ class MDS(MDSRO):
 
     def insert(self, name, doc, validate=False):
         if name != 'bulk_events':
-            self._INS_METHODS[name](validate=validate, **doc)
+            getattr(self, self._INS_METHODS[name])(validate=validate, **doc)
         else:
             for desc_uid, events in doc.items():
                 # If events is empty, mongo chokes.


### PR DESCRIPTION
This obviates `bluesky/register_mds.py`. Registering metadatastore becomes as simple as:

``` python
RE.subscribe('all', metadatastore.commands.insert)
```
