### PR TITLE
FIX: Two small fixes

### DIFF
--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -669,7 +669,7 @@ class MDS(MDSRO):
                                  uid=uid,
                                  validate=validate)
 
-    def bulk_insert_events(self, descriptor, events, validate):
+    def bulk_insert_events(self, descriptor, events, validate=False):
         if self.version == 0:
             raise NotImplementedError("Can not create documents of v0 schema")
         return core.bulk_insert_events(self._event_col,

--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -118,10 +118,18 @@ class MDSRO(object):
 
             self.__event_col.create_index([('uid', pymongo.DESCENDING)],
                                           unique=True)
-            self.__event_col.create_index([('descriptor', pymongo.DESCENDING),
-                                           ('time', pymongo.DESCENDING)],
-                                          unique=False, background=True)
-
+            if self.version == 1:
+                self.__event_col.create_index([('descriptor', pymongo.DESCENDING),
+                                               ('time', pymongo.DESCENDING)],
+                                              unique=False, background=True)
+            elif self.version == 0:
+                self.__event_col.create_index([('descriptor_id',
+                                                pymongo.DESCENDING),
+                                               ('time', pymongo.DESCENDING)],
+                                              unique=False, background=True)
+            else:
+                raise RuntimeError("No rule for event index creation for "
+                                   " schema version {!r}".format(self.version))
         return self.__event_col
 
     def clear_process_cache(self):


### PR DESCRIPTION
See commit messages for details.

The bluesky vertical integration test was not exercising ~~`insert`~~ `insert_bulk_events`, and no tests at all were exercising the version 0 schema. This [migration script](https://gist.github.com/danielballan/b822bebb4e1d7abc5c5cb73b6d9320b7) exercised everything and uncovered these issues.
