### PR TITLE
API: Apply same sorting to v0 as was applied to v1 previously.

### DIFF
--- a/metadatastore/core_v0.py
+++ b/metadatastore/core_v0.py
@@ -11,7 +11,7 @@ import logging
 import pytz
 
 import numpy as np
-
+import pymongo
 import doct as doc
 
 from .core import NoRunStop, NoEventDescriptors
@@ -326,7 +326,8 @@ def descriptors_by_start(run_start, descriptor_col, descriptor_cache,
     run_start = run_start_given_uid(run_start_uid, run_start_col,
                                     run_start_cache)
     oid = _UID_TO_OID_MAP[run_start_uid]
-    descriptors = descriptor_col.find({'run_start_id': oid})
+    descriptors = descriptor_col.find({'run_start_id': oid},
+                                      sort=[('time', pymongo.ASCENDING)])
 
     # loop over the found documents, cache, and dereference
     rets = [_cache_descriptor(descriptor, descriptor_cache,
@@ -365,7 +366,8 @@ def get_events_generator(descriptor, event_col, descriptor_col,
                                       run_start_cache)
     col = event_col
     oid = _UID_TO_OID_MAP[descriptor_uid]
-    ev_cur = col.find({'descriptor_id': oid}, sort=[('time', 1)])
+    ev_cur = col.find({'descriptor_id': oid},
+                      sort=[('time', pymongo.ASCENDING)])
 
     data_keys = descriptor['data_keys']
     for ev in ev_cur:
@@ -885,7 +887,8 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
     """
     # now try rest of formatting
     _format_time(kwargs, tz)
-    rs_objects = run_start_col.find(kwargs)
+    rs_objects = run_start_col.find(kwargs,
+                                    sort=[('time', pymongo.DESCENDING)])
 
     for rs in rs_objects:
         yield _cache_run_start(rs, run_start_cache)
@@ -934,7 +937,8 @@ def find_run_stops(start_col, start_cache,
 
     _format_time(kwargs, tz)
     col = stop_col
-    run_stop = col.find(kwargs)
+    run_stop = col.find(kwargs,
+                        sort=[('time', pymongo.ASCENDING)])
 
     for rs in run_stop:
         yield _cache_run_stop(rs, stop_cache, start_col, start_cache)


### PR DESCRIPTION
We agreed on a sorting for the `find_*` methods in #204, but #204 did not apply that sorting to `core_v0.py`.

This obviously makes validation easier, as the results from v0 and v1 can be zipped and compared.
