### PR TITLE
ENH: Add a wildcard text index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: python
 sudo: false
 services:
 - mongodb
+addons:
+  apt:
+    sources:
+    - mongodb-3.2-precise
+    packages:
+    - mongodb-org-server
 matrix:
   include:
   - python: 2.7

--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -81,6 +81,7 @@ class MDSRO(object):
             self.__runstart_col.create_index([('time', pymongo.DESCENDING),
                                               ('scan_id', pymongo.DESCENDING)],
                                              unique=False, background=True)
+            self.__runstart_col.create_index([("$**", "text")])
 
         return self.__runstart_col
 
@@ -94,6 +95,7 @@ class MDSRO(object):
                                             unique=True)
             self.__runstop_col.create_index([('time', pymongo.DESCENDING)],
                                             unique=False, background=True)
+            self.__runstop_col.create_index([("$**", "text")])
 
         return self.__runstop_col
 
@@ -108,6 +110,7 @@ class MDSRO(object):
                 [('run_start', pymongo.DESCENDING),
                  ('time', pymongo.DESCENDING)],
                 unique=False, background=True)
+            self.__descriptor_col.create_index([("$**", "text")])
 
         return self.__descriptor_col
 


### PR DESCRIPTION
As we migrate to Mongo 3.2 (planned for tomorrow) we can support fast text search, which I demonstrated awhile ago in [this toy project, 'broker search'](https://github.com/NSLS-II/broker-search)

[Relevant section of Mongo docs](https://docs.mongodb.org/manual/core/index-text/#wildcard-text-indexes)
