### PR TITLE
MNT: allow v0 databases to be lightly inconsistent

### DIFF
--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -107,8 +107,7 @@ class MDSRO(object):
         if self.__runstop_col is None:
             self.__runstop_col = self._db.get_collection('run_stop')
             if self.version == 0:
-                self.__runstop_col.create_index('run_start_id',
-                                                unique=True)
+                self.__runstop_col.create_index('run_start_id')
             else:
                 self.__runstop_col.create_index('run_start',
                                                 unique=True)


### PR DESCRIPTION
Some production databases may have multiple run stops for a single
run_start.
