### PR TITLE
API: commands api uses v1 schema

### DIFF
--- a/metadatastore/commands.py
+++ b/metadatastore/commands.py
@@ -17,7 +17,7 @@ from .core import NoEventDescriptors, NoRunStop, NoRunStart
 logger = logging.getLogger(__name__)
 
 
-_DB_SINGLETON = mds.MDS(conf.connection_config, version=0)
+_DB_SINGLETON = mds.MDS(conf.connection_config, version=1)
 
 
 def doc_or_uid_to_uid(doc_or_uid):


### PR DESCRIPTION
attn @arkilic @ericdill 

Once this is merged we need a new tag (v0.6.0) ASAP.  This is so that mds does not try to insert v0 documents into the newly migrated v1 databases.
