### PR TITLE
MNT: enforce unique run_start_id in runstops in v0

### DIFF
--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -107,7 +107,8 @@ class MDSRO(object):
         if self.__runstop_col is None:
             self.__runstop_col = self._db.get_collection('run_stop')
             if self.version == 0:
-                self.__runstop_col.create_index('run_start_id')
+                self.__runstop_col.create_index('run_start_id',
+                                                unique=True)
             else:
                 self.__runstop_col.create_index('run_start',
                                                 unique=True)


### PR DESCRIPTION
This also will poison trying to attach to a v0 database via a v1
speaking client

@ericdill after this we need the tag

attn @arkilic 
