### PR TITLE
MNT: Do not resolve configuration at import time.

### DIFF
--- a/metadatastore/__init__.py
+++ b/metadatastore/__init__.py
@@ -1,5 +1,3 @@
-from . import conf, commands
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
This is what I had in mind. A conf dict with `None`s silently filled in (https://github.com/NSLS-II/metadatastore/pull/230) seems more potentially confusing than a KeyError on importing `metadatastore.conf`.

Would this change, which is analogous to how FS works, provide what metadataservice needs?
