### PR TITLE
Sentinels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 - conda config --add channels lightsource2
 - conda create -n testenv pip pytest python=$TRAVIS_PYTHON_VERSION pymongo six pyyaml numpy pandas jinja2 boltons prettytable humanize doct
 - source activate testenv
+- pip install tzlocal
 - python setup.py install
 - git describe
 - pip install coveralls codecov

--- a/metadatastore/examples/sample_data/common.py
+++ b/metadatastore/examples/sample_data/common.py
@@ -69,28 +69,3 @@ def noisy(val, sigma=0.01):
         return val + sigma * np.random.randn()
     else:
         return val + sigma * np.random.randn(len(val)).reshape(val.shape)
-
-
-get_time = ttime.time
-
-
-def example(func):
-    @wraps(func)
-    def mock_run_start(run_start_uid=None, sleep=0, make_run_stop=True):
-        if run_start_uid is None:
-            run_start_uid = insert_run_start(time=get_time(), scan_id=1,
-                                           beamline_id='example',
-                                           uid=str(uuid.uuid4()))
-
-        # these events are already the sanitized version, not raw mongo objects
-        events = func(run_start_uid, sleep)
-        # Infer the end run time from events, since all the times are
-        # simulated and not necessarily based on the current time.
-        time = max([event['time'] for event in events])
-        if make_run_stop:
-            run_stop_uid = insert_run_stop(run_start_uid, time=time,
-                                         exit_status='success',
-                                         uid=str(uuid.uuid4()))
-            run_stop, = find_run_stops(uid=run_stop_uid)
-        return events
-    return mock_run_start

--- a/metadatastore/examples/sample_data/multisource_event.py
+++ b/metadatastore/examples/sample_data/multisource_event.py
@@ -1,6 +1,7 @@
 from __future__ import division
+import time as ttime
 import uuid
-from metadatastore.api import insert_event, insert_descriptor, find_events
+import metadatastore.commands
 import numpy as np
 from metadatastore.examples.sample_data import common
 
@@ -10,8 +11,11 @@ deadband_size = 0.9
 num_exposures = 23
 
 
-@common.example
-def run(run_start=None, sleep=0):
+def run(run_start=None, sleep=0, mds=metadatastore.commands):
+    run_start = mds.insert_run_start(time=ttime.time(),
+                                     scan_id=1,
+                                     beamline_id='example',
+                                     uid=str(uuid.uuid4()))
     if sleep != 0:
         raise NotImplementedError("A sleep time is not implemented for this "
                                   "example.")
@@ -26,28 +30,29 @@ def run(run_start=None, sleep=0):
                                     dtype='number')}
     data_keys2 = {'Tsam': dict(source='PV:ES:Tsam', dtype='number'),
                   'Troom': dict(source='PV:ES:Troom', dtype='number')}
-    ev_desc1_uid = insert_descriptor(run_start=run_start,
-                                     data_keys=data_keys1,
-                                     time=common.get_time(),
-                                     uid=str(uuid.uuid4()))
-    ev_desc2_uid = insert_descriptor(run_start=run_start,
-                                     data_keys=data_keys2,
-                                     time=common.get_time(),
-                                     uid=str(uuid.uuid4()))
+    ev_desc1_uid = mds.insert_descriptor(run_start=run_start,
+                                        data_keys=data_keys1,
+                                        time=ttime.time(),
+                                        uid=str(uuid.uuid4()))
+    ev_desc2_uid = mds.insert_descriptor(run_start=run_start,
+                                        data_keys=data_keys2,
+                                        time=ttime.time(),
+                                        uid=str(uuid.uuid4()))
     # Create Events.
     events = []
 
     # Point Detector Events
-    base_time = common.get_time()
+    base_time = ttime.time()
     for i in range(num_exposures):
         time = float(i + 0.5 * rs.randn()) + base_time
         data = {'point_det': (point_det_data[i], time)}
         data = {'point_det': point_det_data[i]}
         timestamps = {'point_det': time}
-        event_uid = insert_event(descriptor=ev_desc1_uid, seq_num=i, time=time,
-                                 data=data, uid=str(uuid.uuid4()),
-                                 timestamps=timestamps)
-        event, = find_events(uid=event_uid)
+        event_uid = mds.insert_event(descriptor=ev_desc1_uid, seq_num=i,
+                                     time=time, data=data,
+                                     uid=str(uuid.uuid4()),
+                                     timestamps=timestamps)
+        event, = mds.find_events(uid=event_uid)
         events.append(event)
 
     # Temperature Events
@@ -57,17 +62,20 @@ def run(run_start=None, sleep=0):
                 'Troom': temp + 10}
         timestamps = {'Tsam': time,
                       'Troom': time}
-        event_uid = insert_event(descriptor=ev_desc2_uid, time=time,
-                                 data=data, seq_num=i, uid=str(uuid.uuid4()),
-                                 timestamps=timestamps)
-        event, = find_events(uid=event_uid)
+        event_uid = mds.insert_event(descriptor=ev_desc2_uid, time=time,
+                                     data=data, seq_num=i, uid=str(uuid.uuid4()),
+                                     timestamps=timestamps)
+        event, = mds.find_events(uid=event_uid)
         events.append(event)
+    run_stop_uid = mds.insert_run_stop(run_start, time=time,
+                                       exit_status='success',
+                                       uid=str(uuid.uuid4()))
     return events
 
 
 if __name__ == '__main__':
     import metadatastore.api as mdsc
-    run_start_uid = mdsc.insert_run_start(scan_id=2032013,
+    run_start = mdsc.insert_run_start(scan_id=2032013,
                                           beamline_id='testbed',
                                           owner='tester',
                                           group='awesome-devs',
@@ -75,4 +83,4 @@ if __name__ == '__main__':
                                           time=0.,
                                           uid=str(uuid.uuid4()),)
 
-    run(run_start_uid)
+    run(run_start)

--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -86,6 +86,21 @@ class MDSRO(object):
         if self.__db is None:
             conn = self._connection
             self.__db = conn.get_database(self.config['database'])
+            if self.version > 0:
+                sentinel = self.__db.get_collection('sentinel')
+                versioned_collection = ['run_start', 'run_stop',
+                                        'event_descriptor', 'event']
+                for col_name in versioned_collection:
+                    val = sentinel.find_one({'collection': col_name})
+                    if val is None:
+                        raise RuntimeError('there is no version sentinel for '
+                                           'the {} collection'.format(col_name)
+                                           )
+                    if val['version'] != self.version:
+                        raise RuntimeError('DB version {!r} does not match'
+                                           'API version of FS {} for the '
+                                           '{} collection'.format(
+                                               val, self.version, col_name))
         return self.__db
 
     @property

--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -98,7 +98,7 @@ class MDSRO(object):
                                            )
                     if val['version'] != self.version:
                         raise RuntimeError('DB version {!r} does not match'
-                                           'API version of FS {} for the '
+                                           'API version of MDS {} for the '
                                            '{} collection'.format(
                                                val, self.version, col_name))
         return self.__db

--- a/metadatastore/test/conftest.py
+++ b/metadatastore/test/conftest.py
@@ -1,6 +1,7 @@
 import uuid
 import pytest
 from metadatastore.mds import MDS
+from metadatastore.utils import create_test_database
 
 
 @pytest.fixture(params=[0, 1, 'cmds'], scope='function')
@@ -9,19 +10,19 @@ def mds_all(request):
     temporary database on localhost:27017 with both v0 and v1.
 
     '''
-    db_name = "mds_testing_disposable_{}".format(str(uuid.uuid4()))
-    test_conf = dict(database=db_name, host='localhost',
-                     port=27017, timezone='US/Eastern')
+    db_template = "mds_testing_disposable_{}".format(str(uuid.uuid4()))
     ver = request.param
     obj_api = True
     if ver == 'cmds':
         ver = 1
         obj_api = False
+    test_conf = create_test_database('localhost', db_template=db_template,
+                                     version=ver)
     mds = MDS(test_conf, ver)
 
     def delete_dm():
         print("DROPPING DB")
-        mds._connection.drop_database(db_name)
+        mds._connection.drop_database(test_conf['database'])
 
     request.addfinalizer(delete_dm)
 

--- a/metadatastore/test/test_sample_data.py
+++ b/metadatastore/test/test_sample_data.py
@@ -31,6 +31,8 @@ def test_noisy_for_smoke(v):
     itertools.product([-1, 1], [temperature_ramp, multisource_event])
 )
 def test_sleepy_failures(failing_time, mod):
+    import metadatastore.conf
+    print(metadatastore.conf.connection_config)
     with pytest.raises(NotImplementedError):
         mod.run(sleep=failing_time)
 

--- a/metadatastore/test/test_sample_data.py
+++ b/metadatastore/test/test_sample_data.py
@@ -30,16 +30,14 @@ def test_noisy_for_smoke(v):
     'failing_time, mod',
     itertools.product([-1, 1], [temperature_ramp, multisource_event])
 )
-def test_sleepy_failures(failing_time, mod):
-    import metadatastore.conf
-    print(metadatastore.conf.connection_config)
+def test_sleepy_failures(failing_time, mod, mds_all):
     with pytest.raises(NotImplementedError):
-        mod.run(sleep=failing_time)
+        mod.run(sleep=failing_time, mds=mds_all)
 
 
-def test_multisource_event():
-    multisource_event.run()
+def test_multisource_event(mds_all):
+    multisource_event.run(mds=mds_all)
 
 
-def test_temperature_ramp():
-    temperature_ramp.run()
+def test_temperature_ramp(mds_all):
+    temperature_ramp.run(mds=mds_all)

--- a/metadatastore/test/utils.py
+++ b/metadatastore/test/utils.py
@@ -2,14 +2,10 @@ import uuid
 from metadatastore.api import db_connect, db_disconnect
 from metadatastore import conf
 from copy import deepcopy
+from metadatastore.utils import create_test_database
 
 conn = None
-testing_config = {
-    'database': "mds_testing_disposable_{}".format(str(uuid.uuid4())),
-    'host': 'localhost',
-    'port': 27017,
-    'timezone': 'US/Eastern'}
-
+testing_config = create_test_database('localhost')
 old_connection_info = None
 
 

--- a/metadatastore/utils.py
+++ b/metadatastore/utils.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+import uuid
+from pymongo import MongoClient
+import tzlocal
+
+
+def install_sentinels(config, version):
+    '''Install version sentinel collection
+
+    Parameters
+    ----------
+    config : dict
+        Must have keys {'host', 'database'}, may have key 'port'
+
+    version : int
+        The version of the schema this db uses
+    '''
+    conn = MongoClient(config['host'],
+                       config.get('port', None))
+    db = conn.get_database(config['database'])
+    sentinel = db.get_collection('sentinel')
+
+    versioned_collection = ['run_start', 'run_stop', 'event_descriptor',
+                            'event']
+    for col_name in versioned_collection:
+        val = sentinel.find_one({'collection': col_name})
+        if val is not None:
+            raise RuntimeError('This database already has sentinel '
+                               '{!r}'.format(val))
+        sentinel.insert_one({'collection': col_name, 'version': version})
+
+
+def create_test_database(host, port=None, version=1,
+                         db_template='MDS_test_db_{uid}'):
+    '''Create and initialize a metadatastore database for testing
+
+    Parameters
+    ----------
+    host : str
+       Host of mongo sever
+
+    port : int, optional
+        port running mongo server on host
+
+    version : int, optional
+        The schema version to initialize the db with
+
+    db_template : str, optional
+        Template for database name.  Must have one format entry with the key
+        'uid'.
+
+    Returns
+    -------
+    config : dict
+        Configuration dictionary for the new database.
+
+    '''
+    db_name = db_template.format(uid=str(uuid.uuid4()))
+    config = {'host': host, 'port': port, 'database': db_name,
+              'timezone': tzlocal.get_localzone().zone}
+    install_sentinels(config, version)
+
+    return config


### PR DESCRIPTION
As discussed offline, this future-proofs MDS for the next schema change (which we all hope won't happen for a long time). Deploying it will require running

``` python
from metadatastore.utils import install_sentinels
import metadatastore.conf
install_sentinels(metadatastore.conf.connection_config, 1)
```

just as we did for filestore v0.4.0 deployment.

This copies the sentinels-related code from FS verbatim with only two changes:
- The list of `versioned_collections` has been updated in `install_sentinels` and `self._db` (which checks for sentinels) 
- `create_test_database` returns a config with a timezone -- the local timezone from `tzlocal`

The MDS test utils have also been updated to use `create_test_database`.
