### PR TITLE
ENH: Extend Event Document API to track external keys and filled-ness.

### DIFF
--- a/metadatastore/core.py
+++ b/metadatastore/core.py
@@ -362,6 +362,8 @@ def get_events_generator(descriptor, event_col, descriptor_col,
                             ('time', pymongo.ASCENDING)])
 
     data_keys = descriptor['data_keys']
+    external_keys = [k for k in data_keys if 'external' in data_keys[k]]
+    filled = {k: False for k in external_keys}
     for ev in ev_cur:
         # ditch the ObjectID
         del ev['_id']
@@ -374,6 +376,10 @@ def get_events_generator(descriptor, event_col, descriptor_col,
             if convert_arrays:
                 if _dk['dtype'] == 'array' and not _dk.get('external', False):
                     ev['data'][k] = np.asarray(ev['data'][k])
+
+        # note which keys refer to dereferences (external) data
+        ev['filled'] = filled
+
         # wrap it in our fancy dict
         ev = doc.Document('Event', ev)
 

--- a/metadatastore/core_v0.py
+++ b/metadatastore/core_v0.py
@@ -374,6 +374,8 @@ def get_events_generator(descriptor, event_col, descriptor_col,
                             ('time', pymongo.ASCENDING)])
 
     data_keys = descriptor['data_keys']
+    external_keys = [k for k in data_keys if 'external' in data_keys[k]]
+    filled = {k: False for k in external_keys}
     for ev in ev_cur:
         # ditch the ObjectID
         del ev['_id']
@@ -390,6 +392,10 @@ def get_events_generator(descriptor, event_col, descriptor_col,
             if convert_arrays:
                 if _dk['dtype'] == 'array' and not _dk.get('external', False):
                     ev['data'][k] = np.asarray(ev['data'][k])
+
+        # note which keys refer to dereferences (external) data
+        ev['filled'] = filled
+
         # wrap it in our fancy dict
         ev = doc.Document('Event', ev)
 

--- a/metadatastore/test/test_mds.py
+++ b/metadatastore/test/test_mds.py
@@ -23,6 +23,7 @@ def check_for_id(document):
     with pytest.raises(KeyError):
         document['_id']
 
+
 def setup_syn(mds, custom=None):
     if custom is None:
         custom = {}
@@ -30,6 +31,8 @@ def setup_syn(mds, custom=None):
                      'dtype': 'number',
                      'shape': None} for k in 'ABCEDEFGHIJKL'
                  }
+    data_keys['Z'] = {'source': 'Z', 'dtype': 'array', 'shape': [5, 5],
+                      'external': 'foo'}
     scan_id = 1
 
     # Create a BeginRunEvent that serves as entry point for a run
@@ -276,6 +279,7 @@ def test_bulk_insert(mds_all):
         assert ret['descriptor']['uid'] == e_desc
         for k in ['data', 'timestamps', 'time', 'uid', 'seq_num']:
             assert ret[k] == expt[k]
+        assert ret['filled'] == {'Z': False}
 
 
 def test_bulk_table(mds_all):


### PR DESCRIPTION
Presently, Events don't track whether any external data has been been "filled," and it's easy to write bugs that try to fill an Event twice, blowing up on a filestore error.

The obvious solution would be to stop filling Events in place, but that would mean copying _a lot_ of data in many common cases.

Instead, this PR introduces another parallel dict inside Event:

```
{'data': {'motor': 5, 'image': 'some_uid'},
 'timestamps', {'motor': ..., 'image': ...},
 'filled': {'image': False}
```

When `Broker.fill_event` operates on the document above, it will flip `False` to `True` when replacing `some_uid` with the image array data via filestore. Notice that fields that are not external (like 'motor' above) are not included in `filled`. Whether or not an Event has already been filled, the keys of the `filled` dict provide a quick way to determine which if any fields are external.

The new `filled` features has be introduced here in metadatastore, not databroker, because docts are immutable.
