### PR TITLE
TST: Test that exceptions are included in mds object API.

### DIFF
--- a/metadatastore/test/test_mds.py
+++ b/metadatastore/test/test_mds.py
@@ -417,6 +417,12 @@ def test_fail_runstart(mds_all):
         mdsc.run_start_given_uid('aardvark')
 
 
+def test_exceptions_are_mds_attributes(mds_all):
+    isinstance(mds_all.NoRunStop, Exception)
+    isinstance(mds_all.NoRunStart, Exception)
+    isinstance(mds_all.NoEventDescriptors, Exception)
+
+
 def test_bad_event_desc(mds_all):
     mdsc = mds_all
     data_keys = {k: {'source': k,

--- a/metadatastore/test/test_mds.py
+++ b/metadatastore/test/test_mds.py
@@ -8,8 +8,8 @@ import warnings
 from types import GeneratorType
 from doct import Document
 from metadatastore.mds import MDS
-from metadatastore.core import (NoRunStart, NoEventDescriptors)
 from metadatastore.conf import load_configuration
+
 
 def check_for_id(document):
     """Make sure that our documents do not have an id field
@@ -262,7 +262,7 @@ def test_no_evdesc(mds_all):
         group='awesome-devs', project='Nikea', time=ttime.time(),
         uid=str(uuid.uuid4()))
 
-    with pytest.raises(NoEventDescriptors):
+    with pytest.raises(mds_all.NoEventDescriptors):
         mdsc.descriptors_by_start(run_start_uid)
 
 
@@ -413,7 +413,7 @@ def test_double_run_stop(mds_all):
 
 def test_fail_runstart(mds_all):
     mdsc = mds_all
-    with pytest.raises(NoRunStart):
+    with pytest.raises(mds_all.NoRunStart):
         mdsc.run_start_given_uid('aardvark')
 
 


### PR DESCRIPTION
The main point of making this a formal unit test is ensuring that _other_ MDS implementations don't forget to expose the exceptions as attributes.
