### PR TITLE
API: auth=False by default until it is configurable

### DIFF
--- a/metadatastore/mds.py
+++ b/metadatastore/mds.py
@@ -10,7 +10,7 @@ _API_MAP = {1: core}
 
 
 class MDSRO(object):
-    def __init__(self, config, version=1, auth=True):
+    def __init__(self, config, version=1, auth=False):
         self._RUNSTART_CACHE = {}
         self._RUNSTOP_CACHE = {}
         self._DESCRIPTOR_CACHE = {}


### PR DESCRIPTION
There is no way to configure auth is the connection.yml, which means all analysis envs are broken by the default `auth=True`. We had better roll that back to be conservative. In a separate PR we can make auth configurable via the config files, test that it doesn't break anything, and then change the default back to True.
