### PR TITLE
TST: Fixturize the pickle test.

### DIFF
--- a/metadatastore/test/test_mds.py
+++ b/metadatastore/test/test_mds.py
@@ -63,9 +63,8 @@ def syn_data(data_keys, count):
     return all_data
 
 
-def test_pickle():
-    from metadatastore.mds import MDS
-    md = MDS(config={'host': 'portland'}, version=1)
+def test_pickle(mds_all):
+    md = mds_all(config={'host': 'portland'}, version=1)
     md2 = pickle.loads(pickle.dumps(md))
 
     assert md.version == md2.version


### PR DESCRIPTION
Even if other metadatastore implementations don't support this (and I guess they can...) this should be implement with the fixture.